### PR TITLE
feat(webapp): show family members to all + remove auth method from settings

### DIFF
--- a/apps/webapp/src/app/app/settings/page.tsx
+++ b/apps/webapp/src/app/app/settings/page.tsx
@@ -55,7 +55,7 @@ export default function SettingsPage() {
     <div className="container mx-auto px-4 py-8 max-w-2xl">
       <h1 className="text-2xl font-bold mb-6">Settings</h1>
 
-      <AccountCard userName={vm.userName} authMethod={vm.authMethod} />
+      <AccountCard userName={vm.userName} />
 
       <FamilyCard
         family={vm.family}

--- a/apps/webapp/src/app/app/settings/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/settings/page.ui.spec.tsx
@@ -239,7 +239,7 @@ describe('Settings page', () => {
       });
     });
 
-    it('shows Google label for google auth', async () => {
+    it('shows user name for google auth', async () => {
       currentAuthState = makeGoogleAuthState();
       mockIsLoading = false;
       mockQueryResult = null;
@@ -249,9 +249,6 @@ describe('Settings page', () => {
       await waitFor(() => {
         expect(screen.getByText('Google User')).toBeInTheDocument();
       });
-      // Auth method should show "Google"
-      const authMethodEls = screen.getAllByText('Google');
-      expect(authMethodEls.length).toBeGreaterThan(0);
     });
 
     it('has a link to profile page', async () => {

--- a/apps/webapp/src/features/settings/components/AccountCard.tsx
+++ b/apps/webapp/src/features/settings/components/AccountCard.tsx
@@ -9,14 +9,13 @@ import { Label } from '@/components/ui/label';
 
 export interface AccountCardProps {
   userName: string;
-  authMethod: string;
 }
 
 /**
  * Displays the authenticated user's account information.
  * Shown at the top of the Settings page.
  */
-export function AccountCard({ userName, authMethod }: AccountCardProps) {
+export function AccountCard({ userName }: AccountCardProps) {
   return (
     <Card className="mb-6">
       <CardHeader className="px-4 pt-4 pb-3 sm:px-6 sm:pt-6">
@@ -29,10 +28,6 @@ export function AccountCard({ userName, authMethod }: AccountCardProps) {
         <div className="space-y-0.5">
           <Label className="text-sm text-muted-foreground">Name</Label>
           <p className="text-foreground font-medium">{userName}</p>
-        </div>
-        <div className="space-y-0.5">
-          <Label className="text-sm text-muted-foreground">Auth method</Label>
-          <p className="text-foreground">{authMethod}</p>
         </div>
         <Link href="/app/profile">
           <Button variant="outline" size="sm">

--- a/apps/webapp/src/features/settings/components/FamilyInFamily.tsx
+++ b/apps/webapp/src/features/settings/components/FamilyInFamily.tsx
@@ -178,17 +178,17 @@ export function FamilyInFamily({
             revokingId={revokingId}
             onRevoke={onRevokeInvite}
           />
-
-          {/* Family Members */}
-          <FamilyMembers
-            members={members}
-            isLoading={membersLoading}
-            removingId={removingId}
-            currentUserId={currentUserId}
-            onRemove={onRemoveMember}
-          />
         </>
       )}
+
+      {/* Family Members — visible to all members; remove action is shown only to creator */}
+      <FamilyMembers
+        members={members}
+        isLoading={membersLoading}
+        removingId={removingId}
+        currentUserId={currentUserId}
+        onRemove={onRemoveMember}
+      />
     </div>
   );
 }

--- a/apps/webapp/src/features/settings/components/FamilyInFamily.tsx
+++ b/apps/webapp/src/features/settings/components/FamilyInFamily.tsx
@@ -187,6 +187,7 @@ export function FamilyInFamily({
         isLoading={membersLoading}
         removingId={removingId}
         currentUserId={currentUserId}
+        viewerIsCreator={isCreator}
         onRemove={onRemoveMember}
       />
     </div>

--- a/apps/webapp/src/features/settings/components/FamilyMembers.tsx
+++ b/apps/webapp/src/features/settings/components/FamilyMembers.tsx
@@ -48,6 +48,8 @@ export interface FamilyMembersProps {
   removingId: string | null;
   /** The current user's userId. */
   currentUserId: string | null;
+  /** Whether the current viewer is the family creator (controls remove button visibility). */
+  viewerIsCreator: boolean;
   /** Called when user confirms removal. */
   onRemove: (memberUserId: string) => void;
 }
@@ -61,6 +63,7 @@ export function FamilyMembers({
   isLoading,
   removingId,
   currentUserId,
+  viewerIsCreator,
   onRemove,
 }: FamilyMembersProps) {
   return (
@@ -77,6 +80,7 @@ export function FamilyMembers({
             member={member}
             isRemoving={removingId === member.userId}
             isSelf={member.userId === currentUserId}
+            viewerIsCreator={viewerIsCreator}
             onRemove={onRemove}
           />
         ))}
@@ -91,12 +95,13 @@ interface MemberRowProps {
   member: FamilyMember;
   isRemoving: boolean;
   isSelf: boolean;
+  viewerIsCreator: boolean;
   onRemove: (memberUserId: string) => void;
 }
 
-function MemberRow({ member, isRemoving, isSelf, onRemove }: MemberRowProps) {
+function MemberRow({ member, isRemoving, isSelf, viewerIsCreator, onRemove }: MemberRowProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const canRemove = !member.isCreator && !isSelf; // only creator can remove non-self non-creator members
+  const canRemove = viewerIsCreator && !member.isCreator && !isSelf;
 
   return (
     <div className="flex items-center gap-3 bg-muted/40 p-2.5 rounded-lg">

--- a/apps/webapp/src/features/settings/models/useSettingsViewModel.ts
+++ b/apps/webapp/src/features/settings/models/useSettingsViewModel.ts
@@ -32,8 +32,6 @@ export interface SettingsViewModel {
   isAuthenticated: boolean;
   /** The authenticated user's name, or 'Anonymous user' fallback. */
   userName: string;
-  /** Human-readable authentication method (Google / Anonymous / Unknown). */
-  authMethod: string;
 
   // ── Family data ─────────────────────────────────────────
   /** True while the family query is loading. */
@@ -125,15 +123,6 @@ export function useSettingsViewModel(): SettingsViewModel {
 
   const user = authState?.state === 'authenticated' ? authState.user : undefined;
   const userName = user?.name || 'Anonymous user';
-  // Auth method from the session auth state (not the user document type).
-  const authMethod =
-    authState?.state === 'authenticated' && authState.authMethod
-      ? authState.authMethod === 'google'
-        ? 'Google'
-        : authState.authMethod === 'anonymous'
-          ? 'Anonymous'
-          : authState.authMethod
-      : 'Unknown';
 
   // ── Family query ────────────────────────────────────────
   const family = useSessionQuery(api.web.babyTracker.family.get);
@@ -271,7 +260,6 @@ export function useSettingsViewModel(): SettingsViewModel {
     // Auth
     isAuthenticated,
     userName,
-    authMethod,
 
     // Family data
     familyLoading,
@@ -284,12 +272,12 @@ export function useSettingsViewModel(): SettingsViewModel {
     familyId,
 
     // Invites
-    invites: (invitesResult as InviteInfo[] | undefined) ?? [],
+    invites: Array.isArray(invitesResult) ? (invitesResult as InviteInfo[]) : [],
     invitesLoading: invitesResult === undefined,
     revokingId,
 
     // Members
-    members: (membersResult as FamilyMember[] | undefined) ?? [],
+    members: Array.isArray(membersResult) ? (membersResult as FamilyMember[]) : [],
     membersLoading: membersResult === undefined,
     removingId,
     currentUserId: userId,


### PR DESCRIPTION
## Summary

Two UX improvements to the Settings page.

## Changes

### 1. Family Members visible to all family members

Previously, the `FamilyMembers` list was hidden inside the `{isCreator && ...}` block — only the family creator could see who else was in the family. Non-creator members had no way to see the family roster.

**Fix:** `FamilyMembers` is now rendered for all users in a family. The remove-member button is still only shown to the creator (handled by `FamilyMembers` internally via the `canRemove` logic).

The invite management (`InvitesList`) remains creator-only — non-creators don't need to see sent invites.

### 2. Auth method removed from Account card

The "Auth method" field (e.g., "Google", "Anonymous") is removed from the Account card in Settings. The `authMethod` field is removed from `useSettingsViewModel` and `AccountCard`.

**Also:** Added defensive `Array.isArray()` guards in `useSettingsViewModel` for the `members` and `invites` query results — prevents crashes if a query unexpectedly returns a non-array value.

## Test changes

- Removed the now-invalid "shows Google label for google auth" test assertion (which checked for the auth method display)
- Renamed test to "shows user name for google auth"
- 166/166 tests pass ✅

typecheck ✅ | tests ✅