### PR TITLE
feat(webapp): port breast timer to latch feed create page with localStorage persistence

### DIFF
--- a/apps/webapp/src/app/app/feed/create/page.tsx
+++ b/apps/webapp/src/app/app/feed/create/page.tsx
@@ -12,7 +12,8 @@ import { Label } from '@/components/ui/label';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuthState } from '@/modules/auth/AuthProvider';
-import { getDefaultDatetime, toSeconds, toTimestamp } from '@/lib/activity-form-utils';
+import { getDefaultDatetime, toSeconds, toMinutesSeconds, toTimestamp } from '@/lib/activity-form-utils';
+import { BreastTimer } from '@/components/BreastTimer';
 
 // ── Feed types ──────────────────────────────────────────────────
 
@@ -214,6 +215,20 @@ export default function FeedCreatePage() {
                       />
                     </div>
                   </div>
+                </div>
+
+                {/* Breast timer */}
+                <div className="pt-2 border-t border-border">
+                  <BreastTimer
+                    onUpdate={({ left, right }) => {
+                      const { min: lMin, sec: lSec } = toMinutesSeconds(left);
+                      const { min: rMin, sec: rSec } = toMinutesSeconds(right);
+                      setLeftMin(String(lMin));
+                      setLeftSec(String(lSec));
+                      setRightMin(String(rMin));
+                      setRightSec(String(rSec));
+                    }}
+                  />
                 </div>
               </div>
             )}

--- a/apps/webapp/src/app/app/feed/create/page.tsx
+++ b/apps/webapp/src/app/app/feed/create/page.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { getDefaultDatetime, toSeconds, toMinutesSeconds, toTimestamp } from '@/lib/activity-form-utils';
 import { BreastTimer } from '@/components/BreastTimer';
+import { BREAST_TIMER_STORAGE_KEY } from '@/hooks/useBreastTimer';
 
 // ── Feed types ──────────────────────────────────────────────────
 
@@ -103,6 +104,11 @@ export default function FeedCreatePage() {
           feed,
         },
       } as any);
+
+      // Clear the breast timer session on successful save
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem(BREAST_TIMER_STORAGE_KEY);
+      }
 
       router.push('/app');
     } finally {

--- a/apps/webapp/src/components/BreastTimer.tsx
+++ b/apps/webapp/src/components/BreastTimer.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { Play, Square, RotateCcw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+import { useBreastTimer, formatElapsed } from '@/hooks/useBreastTimer';
+
+export interface BreastTimerProps {
+  /** Called when a timer side is stopped. Provides seconds for left and right. */
+  onUpdate: (result: { left: number; right: number }) => void;
+}
+
+/**
+ * Two-side breast timer with start/stop/reset controls.
+ * Calls onUpdate with elapsed seconds for both sides when either side stops.
+ */
+export function BreastTimer({ onUpdate }: BreastTimerProps) {
+  const timer = useBreastTimer();
+
+  const handleToggle = (side: 'left' | 'right') => {
+    const wasActive = side === 'left' ? timer.left.isActive : timer.right.isActive;
+    const elapsedLeft = timer.left.elapsedMs;
+    const elapsedRight = timer.right.elapsedMs;
+
+    timer.toggle(side);
+
+    if (wasActive) {
+      onUpdate({
+        left: Math.floor(elapsedLeft / 1000),
+        right: Math.floor(elapsedRight / 1000),
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Timer displays */}
+      <div className="flex gap-3">
+        {/* Left */}
+        <div className="flex-1 flex flex-col items-center gap-1.5">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+            Left
+          </p>
+          <p className="text-2xl font-mono font-medium text-foreground tabular-nums">
+            {formatElapsed(timer.left.elapsedMs)}
+          </p>
+          <Button
+            variant={timer.left.isActive ? 'destructive' : 'outline'}
+            size="sm"
+            onClick={() => handleToggle('left')}
+            className="w-full"
+          >
+            {timer.left.isActive ? (
+              <>
+                <Square className="h-3.5 w-3.5 mr-1.5" />
+                Stop
+              </>
+            ) : (
+              <>
+                <Play className="h-3.5 w-3.5 mr-1.5" />
+                Start
+              </>
+            )}
+          </Button>
+        </div>
+
+        {/* Right */}
+        <div className="flex-1 flex flex-col items-center gap-1.5">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+            Right
+          </p>
+          <p className="text-2xl font-mono font-medium text-foreground tabular-nums">
+            {formatElapsed(timer.right.elapsedMs)}
+          </p>
+          <Button
+            variant={timer.right.isActive ? 'destructive' : 'outline'}
+            size="sm"
+            onClick={() => handleToggle('right')}
+            className="w-full"
+          >
+            {timer.right.isActive ? (
+              <>
+                <Square className="h-3.5 w-3.5 mr-1.5" />
+                Stop
+              </>
+            ) : (
+              <>
+                <Play className="h-3.5 w-3.5 mr-1.5" />
+                Start
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* Reset */}
+      {timer.hasActivity && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={timer.reset}
+          className="w-full text-muted-foreground hover:text-foreground"
+        >
+          <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+          Reset timer
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/webapp/src/hooks/useBreastTimer.ts
+++ b/apps/webapp/src/hooks/useBreastTimer.ts
@@ -1,0 +1,145 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+// ── Types ─────────────────────────────────────────────────────
+
+export type BreastSide = 'left' | 'right';
+
+export interface TimerAction {
+  side: BreastSide;
+  type: 'start' | 'stop';
+  timestamp: number; // epoch ms
+}
+
+export interface BreastTimerSession {
+  version: 1;
+  createdAt: number;
+  actions: TimerAction[];
+}
+
+export interface SideState {
+  elapsedMs: number; // total milliseconds
+  isActive: boolean;
+}
+
+export interface BreastTimerState {
+  left: SideState;
+  right: SideState;
+  toggle: (side: BreastSide) => void;
+  reset: () => void;
+  hasActivity: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────
+
+const STORAGE_KEY = 'baby-tracker:breast-timer';
+const STALE_MS = 8 * 60 * 60 * 1000; // 8 hours
+
+/** Compute elapsed time and active state for one side from the action log. */
+function computeSideElapsed(
+  actions: TimerAction[],
+  side: BreastSide,
+  now: number
+): SideState {
+  const sideActions = actions.filter((a) => a.side === side);
+  let elapsedMs = 0;
+  let prevStart: number | null = null;
+
+  for (const action of sideActions) {
+    if (action.type === 'start') {
+      prevStart = action.timestamp;
+    } else if (action.type === 'stop' && prevStart !== null) {
+      elapsedMs += action.timestamp - prevStart;
+      prevStart = null;
+    }
+  }
+
+  // If still active, add running interval up to `now`
+  if (prevStart !== null) {
+    elapsedMs += now - prevStart;
+  }
+
+  const lastAction = sideActions[sideActions.length - 1];
+  const isActive = lastAction?.type === 'start';
+  return { elapsedMs, isActive };
+}
+
+/** Format elapsed milliseconds as "MM:SS" or "H:MM:SS". */
+export function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.floor(elapsedMs / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) {
+    return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+// ── Hook ────────────────────────────────────────────────
+
+export function useBreastTimer(): BreastTimerState {
+  // Load from localStorage on mount
+  const [actions, setActions] = useState<TimerAction[]>(() => {
+    if (typeof window === 'undefined') return [];
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const session: BreastTimerSession = JSON.parse(raw);
+      if (session.version !== 1) return [];
+      if (Date.now() - session.createdAt > STALE_MS) return [];
+      return session.actions;
+    } catch {
+      return [];
+    }
+  });
+
+  // Tick for live elapsed display
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Persist to localStorage whenever actions change
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (actions.length === 0) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    const createdAt = actions[0]?.timestamp ?? Date.now();
+    const session: BreastTimerSession = { version: 1, createdAt, actions };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  }, [actions]);
+
+  // Toggle start/stop for a side
+  const toggle = useCallback(
+    (side: BreastSide) => {
+      setActions((prev) => {
+        const sideActions = prev.filter((a) => a.side === side);
+        const lastAction = sideActions[sideActions.length - 1];
+        const isActive = lastAction?.type === 'start';
+        return [
+          ...prev,
+          { side, type: isActive ? 'stop' : 'start', timestamp: Date.now() },
+        ];
+      });
+    },
+    []
+  );
+
+  const reset = useCallback(() => {
+    setActions([]);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const left = useMemo(() => computeSideElapsed(actions, 'left', now), [actions, now]);
+  const right = useMemo(() => computeSideElapsed(actions, 'right', now), [actions, now]);
+  const hasActivity = actions.length > 0;
+
+  return { left, right, toggle, reset, hasActivity };
+}

--- a/apps/webapp/src/hooks/useBreastTimer.ts
+++ b/apps/webapp/src/hooks/useBreastTimer.ts
@@ -34,6 +34,8 @@ export interface BreastTimerState {
 // ── Helpers ───────────────────────────────────────────────
 
 const STORAGE_KEY = 'baby-tracker:breast-timer';
+/** Export the storage key for use in parent components that need to clear the timer on save. */
+export const BREAST_TIMER_STORAGE_KEY = STORAGE_KEY;
 const STALE_MS = 8 * 60 * 60 * 1000; // 8 hours
 
 /** Compute elapsed time and active state for one side from the action log. */


### PR DESCRIPTION
## Summary

Ports the mobile app's breast timer feature to the webapp's latch feed create page. Duplicates the mobile implementation (no code sharing) with added localStorage persistence for refresh survival.

## Architecture

### `apps/webapp/src/hooks/useBreastTimer.ts`

Port of mobile's `useStopwatch`, adapted for:
- **Left + Right tracking** in one hook (vs two separate hook instances on mobile)
- **localStorage persistence** — action log survives page refreshes
- **Stale session detection** — sessions older than 8h are discarded on mount (clean slate)
- **JSON-serializable timestamps** — epoch ms instead of Luxon DateTime for storage

**Action log model** (same as mobile):
```ts
{ side: 'left'|'right', type: 'start'|'stop', timestamp: epochMs }[]
```

Elapsed is computed from the log at render time, not stored. This means pause/resume works correctly across any number of start/stop cycles.

### `apps/webapp/src/components/BreastTimer.tsx`

Two-column UI:
- Left + Right elapsed displays (`MM:SS` / `H:MM:SS`)
- Start (`Play` icon) / Stop (`Square` icon, destructive variant) per side
- Reset button (`RotateCcw`) shown once any activity recorded
- Calls `onUpdate({ left, right })` in **seconds** when a side stops

### `apps/webapp/src/app/app/feed/create/page.tsx`

`BreastTimer` added below the manual min/sec inputs in the latch section. `onUpdate` populates all 4 min/sec fields using `toMinutesSeconds()`.

## User flow

1. Select **Latch** feed type
2. Use **Start/Stop** buttons to time each breast side
3. When a side stops, min/sec fields are auto-filled
4. Page refresh → timer resumes from where it left off (localStorage)
5. Hit **Save** → activity saved with correct durations
6. Hit **Reset** → clears timer and localStorage for a fresh start

typecheck ✅ | tests ✅