### PR TITLE
feat(webapp): move activity edit Delete action to top-right kebab menu

### DIFF
--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
-import { Baby, ChevronLeft } from 'lucide-react';
+import { Baby, ChevronLeft, MoreVertical, Trash2 } from 'lucide-react';
 import { useSessionQuery, useSessionMutation } from 'convex-helpers/react/sessions';
 import { api } from '@workspace/backend/convex/_generated/api';
 import { Id } from '@workspace/backend/convex/_generated/dataModel';
@@ -12,6 +12,12 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { toLocalDatetimeString, toTimestamp } from '@/lib/activity-form-utils';
 
@@ -151,6 +157,25 @@ export default function DiaperEditPage() {
         </button>
         <Baby className="h-6 w-6 text-green-600 dark:text-green-400" />
         <h1 className="text-xl font-bold">Edit Diaper Change</h1>
+        <div className="ml-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="More options">
+                <MoreVertical className="h-5 w-5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={handleDelete}
+                disabled={deleting}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
 
       <div className="flex flex-col gap-3">
@@ -202,9 +227,6 @@ export default function DiaperEditPage() {
         <Button variant="ghost" onClick={() => router.push('/app')}>Cancel</Button>
         <Button className="flex-1" onClick={handleSave} disabled={saving}>
           {saving ? 'Saving...' : 'Save'}
-        </Button>
-        <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleting}>
-          Delete
         </Button>
       </div>
     </div>

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.ui.spec.tsx
@@ -215,13 +215,17 @@ describe('Diaper change edit page', () => {
   // ── 5. Delete ─────────────────────────────────────────────────
 
   describe('delete', () => {
-    it('renders a Delete button', async () => {
+    it('renders a Delete button in the kebab menu', async () => {
+      const user = userEvent.setup();
       mockQueryResult = EXISTING_DIRTY;
       render(<DiaperEditPage />);
 
       await waitFor(() => {
-        expect(screen.getByText('Delete')).toBeInTheDocument();
+        expect(screen.getByLabelText('More options')).toBeInTheDocument();
       });
+
+      await user.click(screen.getByLabelText('More options'));
+      expect(await screen.findByText('Delete')).toBeInTheDocument();
     });
 
     it('calls delete mutation then navigates to activities', async () => {
@@ -230,10 +234,11 @@ describe('Diaper change edit page', () => {
       render(<DiaperEditPage />);
 
       await waitFor(() => {
-        expect(screen.getByText('Delete')).toBeInTheDocument();
+        expect(screen.getByLabelText('More options')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Delete'));
+      await user.click(screen.getByLabelText('More options'));
+      await user.click(await screen.findByText('Delete'));
 
       await waitFor(() => {
         expect(mockMutate).toHaveBeenCalledWith({

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
-import { Milk, ChevronLeft } from 'lucide-react';
+import { Milk, ChevronLeft, MoreVertical, Trash2 } from 'lucide-react';
 import { useSessionQuery, useSessionMutation } from 'convex-helpers/react/sessions';
 import { api } from '@workspace/backend/convex/_generated/api';
 import { Id } from '@workspace/backend/convex/_generated/dataModel';
@@ -13,6 +13,12 @@ import { Label } from '@/components/ui/label';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { toSeconds, toMinutesSeconds, toLocalDatetimeString, toTimestamp } from '@/lib/activity-form-utils';
 
@@ -223,6 +229,25 @@ export default function FeedEditPage() {
         </button>
         <Milk className="h-6 w-6 text-blue-600 dark:text-blue-400" />
         <h1 className="text-xl font-bold">Edit Feed</h1>
+        <div className="ml-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="More options">
+                <MoreVertical className="h-5 w-5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={handleDelete}
+                disabled={deleting}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
 
       <div className="flex flex-col gap-3">
@@ -369,9 +394,6 @@ export default function FeedEditPage() {
         <Button variant="ghost" onClick={() => router.push('/app')}>Cancel</Button>
         <Button className="flex-1" onClick={handleSave} disabled={saving}>
           {saving ? 'Saving...' : 'Save'}
-        </Button>
-        <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleting}>
-          Delete
         </Button>
       </div>
     </div>

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.ui.spec.tsx
@@ -354,13 +354,17 @@ describe('Feed edit page', () => {
   // ── 8. Delete activity ────────────────────────────────────────
 
   describe('delete', () => {
-    it('renders a Delete button', async () => {
+    it('renders a Delete button in the kebab menu', async () => {
+      const user = userEvent.setup();
       mockQueryResult = makeLatchQueryResult();
       render(<FeedEditPage />);
 
       await waitFor(() => {
-        expect(screen.getByText('Delete')).toBeInTheDocument();
+        expect(screen.getByLabelText('More options')).toBeInTheDocument();
       });
+
+      await user.click(screen.getByLabelText('More options'));
+      expect(await screen.findByText('Delete')).toBeInTheDocument();
     });
 
     it('calls delete mutation then navigates to activities', async () => {
@@ -369,10 +373,11 @@ describe('Feed edit page', () => {
       render(<FeedEditPage />);
 
       await waitFor(() => {
-        expect(screen.getByText('Delete')).toBeInTheDocument();
+        expect(screen.getByLabelText('More options')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Delete'));
+      await user.click(screen.getByLabelText('More options'));
+      await user.click(await screen.findByText('Delete'));
 
       await waitFor(() => {
         expect(mockMutate).toHaveBeenCalledWith({

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
-import { Stethoscope, ChevronLeft } from 'lucide-react';
+import { Stethoscope, ChevronLeft, MoreVertical, Trash2 } from 'lucide-react';
 import { useSessionQuery, useSessionMutation } from 'convex-helpers/react/sessions';
 import { api } from '@workspace/backend/convex/_generated/api';
 import { Id } from '@workspace/backend/convex/_generated/dataModel';
@@ -13,6 +13,12 @@ import { Label } from '@/components/ui/label';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { toLocalDatetimeString, toTimestamp } from '@/lib/activity-form-utils';
 
@@ -188,6 +194,25 @@ export default function MedicalEditPage() {
         </button>
         <Stethoscope className="h-6 w-6 text-rose-600 dark:text-rose-400" />
         <h1 className="text-xl font-bold">Edit Medical</h1>
+        <div className="ml-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" aria-label="More options">
+                <MoreVertical className="h-5 w-5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={handleDelete}
+                disabled={deleting}
+                className="text-destructive focus:text-destructive"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
 
       <div className="flex flex-col gap-3">
@@ -297,9 +322,6 @@ export default function MedicalEditPage() {
         <Button variant="ghost" onClick={() => router.push('/app')}>Cancel</Button>
         <Button className="flex-1" onClick={handleSave} disabled={saving}>
           {saving ? 'Saving...' : 'Save'}
-        </Button>
-        <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleting}>
-          Delete
         </Button>
       </div>
     </div>

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.ui.spec.tsx
@@ -293,13 +293,17 @@ describe('Medical edit page', () => {
   // ── 7. Delete ─────────────────────────────────────────────────
 
   describe('delete', () => {
-    it('renders a Delete button', async () => {
+    it('renders a Delete button in the kebab menu', async () => {
+      const user = userEvent.setup();
       mockQueryResult = EXISTING_TEMPERATURE;
       render(<MedicalEditPage />);
 
       await waitFor(() => {
-        expect(screen.getByText('Delete')).toBeInTheDocument();
+        expect(screen.getByLabelText('More options')).toBeInTheDocument();
       });
+
+      await user.click(screen.getByLabelText('More options'));
+      expect(await screen.findByText('Delete')).toBeInTheDocument();
     });
 
     it('calls delete mutation then navigates', async () => {
@@ -308,10 +312,11 @@ describe('Medical edit page', () => {
       render(<MedicalEditPage />);
 
       await waitFor(() => {
-        expect(screen.getByText('Delete')).toBeInTheDocument();
+        expect(screen.getByLabelText('More options')).toBeInTheDocument();
       });
 
-      await user.click(screen.getByText('Delete'));
+      await user.click(screen.getByLabelText('More options'));
+      await user.click(await screen.findByText('Delete'));
 
       await waitFor(() => {
         expect(mockMutate).toHaveBeenCalledWith({ activityId: 'act-med-1' });


### PR DESCRIPTION
## Summary

Moves the Delete action on all three activity edit pages from the bottom-right destructive button to a kebab (three-vertical-dot) menu in the top-right of the page header. Improves discoverability/safety by keeping a destructive action out of the primary tap area while making it consistently available.

## Pages Updated

- `apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx`
- `apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx`
- `apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx`

## Changes Per Page

- Header row gains an `ml-auto` group with a `DropdownMenu` triggered by a ghost icon-button (`MoreVertical`, aria-label "More options").
- Menu contains a single destructive `DropdownMenuItem` — `Trash2` + "Delete" — styled with `text-destructive focus:text-destructive`, disabled while the delete mutation is in flight.
- Bottom action row simplified to Cancel + Save only.
- Existing `handleDelete` behavior unchanged (immediate delete, no confirmation dialog, same mutation + navigation).

## Tests

Updated the three `page.ui.spec.tsx` files to open the kebab menu before clicking Delete.

- `pnpm typecheck` — passes
- `pnpm test` — passes (all 169 webapp tests)

## Test Plan (Manual)

1. Edit a feed activity → confirm no Delete button at the bottom; top-right has a 3-dot menu.
2. Tap the menu → "Delete" appears with a trash icon in destructive color.
3. Tap Delete → activity is removed and you navigate back to /app.
4. Repeat for a diaper-change activity and a medical activity.
5. Verify in dark mode that the destructive color is still legible.

## Out of Scope

- No confirmation dialog (matches existing UX).
- Extracting a shared `<EditPageHeader />` for the now-duplicated menu block — worth doing if a second menu action lands.
