### PR TITLE
perf(webapp): prefetch activity edit links from activity list

### DIFF
--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 import { Clock, FlaskConical, Calendar, Loader2, Milk, Baby, Stethoscope, Sunrise, Sun, Moon, Stars } from 'lucide-react';
@@ -449,9 +450,10 @@ export default function AppHomePage() {
                       const isLastOverall = isLastTimeGroup && isLastInGroup;
 
                       return (
-                        <button
+                        <Link
                           key={activity._id as string}
-                          onClick={() => router.push(getEditPath(activity))}
+                          href={getEditPath(activity)}
+                          prefetch={true}
                           className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-accent/50 transition-colors ${!isLastOverall ? 'border-b border-border' : ''}`}
                         >
                           <span className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-muted">
@@ -468,7 +470,7 @@ export default function AppHomePage() {
                           <span className="text-xs text-muted-foreground flex-shrink-0">
                             {formatTime(activity.timestamp as string)}
                           </span>
-                        </button>
+                        </Link>
                       );
                     })}
                   </div>

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -508,7 +508,7 @@ describe('App home page', () => {
   // ── 7. Row click navigation (new edit paths) ──────────────────
 
   describe('row click navigation', () => {
-    it('navigates to feed edit page at /app/feed/edit/[id]', async () => {
+    it('links to feed edit page at /app/feed/edit/[id]', async () => {
       mockResults = [makeLatchActivity({ _id: 'act-feed-1' })];
       mockIsLoading = false;
       mockStatus = 'Exhausted';
@@ -519,14 +519,11 @@ describe('App home page', () => {
         expect(screen.getByText('Latch Feed')).toBeInTheDocument();
       });
 
-      screen.getByText('Latch Feed').closest('button')?.click();
-
-      await waitFor(() => {
-        expect(mockRouterPush).toHaveBeenCalledWith('/app/feed/edit/act-feed-1');
-      });
+      const link = screen.getByText('Latch Feed').closest('a');
+      expect(link).toHaveAttribute('href', '/app/feed/edit/act-feed-1');
     });
 
-    it('navigates to diaper edit page at /app/diaper-change/edit/[id]', async () => {
+    it('links to diaper edit page at /app/diaper-change/edit/[id]', async () => {
       mockResults = [makeDiaperActivity({ _id: 'act-diaper-1' })];
       mockIsLoading = false;
       mockStatus = 'Exhausted';
@@ -537,14 +534,11 @@ describe('App home page', () => {
         expect(screen.getByText('Diaper Change')).toBeInTheDocument();
       });
 
-      screen.getByText('Diaper Change').closest('button')?.click();
-
-      await waitFor(() => {
-        expect(mockRouterPush).toHaveBeenCalledWith('/app/diaper-change/edit/act-diaper-1');
-      });
+      const link = screen.getByText('Diaper Change').closest('a');
+      expect(link).toHaveAttribute('href', '/app/diaper-change/edit/act-diaper-1');
     });
 
-    it('navigates to medical edit page at /app/medical/edit/[id]', async () => {
+    it('links to medical edit page at /app/medical/edit/[id]', async () => {
       mockResults = [makeTemperatureActivity({ _id: 'act-med-1' })];
       mockIsLoading = false;
       mockStatus = 'Exhausted';
@@ -555,11 +549,8 @@ describe('App home page', () => {
         expect(screen.getByText('Temperature')).toBeInTheDocument();
       });
 
-      screen.getByText('Temperature').closest('button')?.click();
-
-      await waitFor(() => {
-        expect(mockRouterPush).toHaveBeenCalledWith('/app/medical/edit/act-med-1');
-      });
+      const link = screen.getByText('Temperature').closest('a');
+      expect(link).toHaveAttribute('href', '/app/medical/edit/act-med-1');
     });
   });
 


### PR DESCRIPTION
## Summary

Makes navigation from the activity list to an activity edit page noticeably snappier by converting the activity-list row from `<button onClick={() => router.push(...)}>` to a Next.js `<Link href={...} prefetch={true}>`. With prefetch enabled, Next.js fetches the edit-page route on hover and as rows enter the viewport, so the click → render transition feels instantaneous.

## Files Changed

- `apps/webapp/src/app/app/page.tsx` — replace `<button>` row with `<Link>`, same children & className
- `apps/webapp/src/app/app/page.ui.spec.tsx` — row-click navigation tests now assert on the rendered anchor's `href` attribute

## Scope

- Only the activity-list rows (`app/page.tsx` ~line 452). The Log Feed / Log Diaper / Log Medical create buttons are intentionally untouched.

## Test Plan

- Hover an activity row → DevTools Network panel should show a prefetch request for the edit route's RSC payload.
- Click an activity row → edit page renders without the previous loading flash.
- Verify each activity type (feed, diaper-change, medical) navigates to the correct edit URL.

## Verification

- `pnpm typecheck` — passes
- `pnpm test` — passes (169 webapp tests)
