### PR TITLE
feat(webapp): replace feeding summary with last-24h summary card

### DIFF
--- a/apps/webapp/src/app/app/page.test.tsx
+++ b/apps/webapp/src/app/app/page.test.tsx
@@ -42,6 +42,7 @@ vi.mock('convex-helpers/react/sessions', () => ({
     isLoading: false,
     loadMore: vi.fn(),
   }),
+  useSessionQuery: () => null,
 }));
 
 // Mutable auth state

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -3,9 +3,9 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
-import { Clock, FlaskConical, Calendar, Loader2, Milk, Baby, Stethoscope, Sunrise, Sun, Moon, Stars } from 'lucide-react';
+import { Loader2, Milk, Baby, Stethoscope, Sunrise, Sun, Moon, Stars } from 'lucide-react';
 import { DateTime } from 'luxon';
-import { useSessionPaginatedQuery } from 'convex-helpers/react/sessions';
+import { useSessionPaginatedQuery, useSessionQuery } from 'convex-helpers/react/sessions';
 import { api } from '@workspace/backend/convex/_generated/api';
 
 import { Button } from '@/components/ui/button';
@@ -14,12 +14,13 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { computeDailySummariesByDay, DailySummary } from '@/lib/daily-summary';
 import { DailySummaryCard } from '@/modules/baby-tracker/DailySummaryCard';
+import { Last24hSummaryCard } from '@/modules/baby-tracker/Last24hSummaryCard';
+import { useNowBucket5Min } from '@/lib/use-now-bucket';
 import {
   formatTime,
   formatDate,
   toDateKey,
   formatDuration,
-  timeAgoFromMs,
 } from '@/lib/activity-form-utils';
 
 // ── Helpers ─────────────────────────────────────────────────────
@@ -135,81 +136,6 @@ const TIME_OF_DAY_META: Record<TimeOfDay, { label: string; Icon: React.Component
 };
 
 
-// ── Summary Stats ───────────────────────────────────────────────
-
-interface SummaryStats {
-  isValid: boolean;
-  lastFeedTimeAgo: string | null;
-  threeHourlyVolume: number;
-  twentyFourHourVolume: number;
-}
-
-// timeAgoFromMs imported from @/lib/activity-form-utils
-
-
-/** Compute summary stats from activities (mirrors mobile logic). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function computeSummaryStats(activities: any[]): SummaryStats {
-  const now = Date.now();
-  const twentyFourHoursAgo = now - 24 * 60 * 60 * 1000;
-
-  let lastFeedTimestamp: string | null = null;
-  let lastFeedDateMs = 0;
-
-  const bottleFeedsIn24h: { dateMs: number; volumeMl: number }[] = [];
-
-  for (const activity of activities) {
-    const ts = activity.timestamp as string;
-    const dateMs = DateTime.fromISO(ts).toMillis();
-
-    if (activity.type === 'feed') {
-      if (dateMs <= now && dateMs > lastFeedDateMs) {
-        lastFeedDateMs = dateMs;
-        lastFeedTimestamp = ts;
-      }
-
-      const feedType = activity.feed?.type;
-      if (
-        (feedType === 'expressed' || feedType === 'formula' || feedType === 'water') &&
-        dateMs > twentyFourHoursAgo &&
-        dateMs <= now
-      ) {
-        bottleFeedsIn24h.push({
-          dateMs,
-          volumeMl: activity.feed?.volume?.ml ?? 0,
-        });
-      }
-    }
-  }
-
-  bottleFeedsIn24h.sort((a, b) => b.dateMs - a.dateMs);
-
-  const result: SummaryStats = {
-    isValid: false,
-    lastFeedTimeAgo: null,
-    threeHourlyVolume: 0,
-    twentyFourHourVolume: 0,
-  };
-
-  if (lastFeedTimestamp) {
-    result.lastFeedTimeAgo = timeAgoFromMs(now - lastFeedDateMs);
-  }
-
-  if (bottleFeedsIn24h.length < 2) return result;
-
-  const latest = bottleFeedsIn24h[0];
-  const earliest = bottleFeedsIn24h[bottleFeedsIn24h.length - 1];
-  const totalVol = bottleFeedsIn24h.reduce((sum, f) => sum + f.volumeMl, 0);
-  const totalDurationMins = (latest.dateMs - earliest.dateMs) / (60 * 1000);
-  if (totalDurationMins <= 0) return result;
-
-  const minutelyVolume = (totalVol - latest.volumeMl) / totalDurationMins;
-  result.threeHourlyVolume = Math.ceil(minutelyVolume * 60 * 3);
-  result.twentyFourHourVolume = totalVol;
-  result.isValid = true;
-  return result;
-}
-
 // ── Quick Action Grid (shared across states) ────────────────────
 
 function QuickActionGrid({ router }: { router: ReturnType<typeof useRouter> }) {
@@ -258,8 +184,9 @@ export default function AppHomePage() {
   const isLoading = paginated?.isLoading ?? true;
   const loadMore = paginated?.loadMore;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const summaryStats = useMemo(() => computeSummaryStats(results as any[]), [results]);
+  const nowIso = useNowBucket5Min();
+  const nowMs = DateTime.fromISO(nowIso).toMillis();
+  const last24h = useSessionQuery(api.web.babyTracker.activities.getLast24hSummary, { nowIso });
 
   // ── Per-day summary computation ──────────────────────────────
   const dailySummariesByDay = useMemo(() => computeDailySummariesByDay(results), [results]);
@@ -392,39 +319,8 @@ export default function AppHomePage() {
     <div className="container mx-auto px-4 py-8 max-w-2xl">
       <QuickActionGrid router={router} />
 
-      {/* Summary card — only when feed data exists */}
-      {summaryStats.lastFeedTimeAgo && (
-        <Card className="mb-6 bg-rose-50 dark:bg-rose-950/20 border-rose-200 dark:border-rose-800">
-          <CardContent className="p-4">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400 mb-4">
-              Feeding Summary
-            </h2>
-            <div className="flex justify-between">
-              <div className="flex flex-col items-center flex-1 gap-0.5">
-                <Clock className="h-5 w-5 text-rose-500 dark:text-rose-400" />
-                <span className="text-xs text-rose-600 dark:text-rose-400 mt-1">Last Feed</span>
-                <span className="text-base font-bold text-rose-900 dark:text-rose-200">
-                  {summaryStats.lastFeedTimeAgo}
-                </span>
-              </div>
-              <div className="flex flex-col items-center flex-1 gap-0.5">
-                <FlaskConical className="h-5 w-5 text-rose-500 dark:text-rose-400" />
-                <span className="text-xs text-rose-600 dark:text-rose-400 mt-1">3h Avg</span>
-                <span className="text-base font-bold text-rose-900 dark:text-rose-200">
-                  {summaryStats.threeHourlyVolume} ml
-                </span>
-              </div>
-              <div className="flex flex-col items-center flex-1 gap-0.5">
-                <Calendar className="h-5 w-5 text-rose-500 dark:text-rose-400" />
-                <span className="text-xs text-rose-600 dark:text-rose-400 mt-1">24h Total</span>
-                <span className="text-base font-bold text-rose-900 dark:text-rose-200">
-                  {summaryStats.twentyFourHourVolume} ml
-                </span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      {/* Last 24h summary */}
+      {last24h && <Last24hSummaryCard summary={last24h} nowMs={nowMs} />}
 
       {/* Grouped activity list */}
       {groupedByDate.map((dateGroup) => {

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -47,6 +47,8 @@ let mockStatus: string = 'Exhausted';
 let mockIsLoading = false;
 const mockLoadMore = vi.fn();
 
+let mockLast24h: Record<string, unknown> | null = null;
+
 vi.mock('convex-helpers/react/sessions', () => ({
   SessionProvider: ({ children }: { children: ReactNode }) => children,
   useSessionPaginatedQuery: () => ({
@@ -55,6 +57,7 @@ vi.mock('convex-helpers/react/sessions', () => ({
     isLoading: mockIsLoading,
     loadMore: mockLoadMore,
   }),
+  useSessionQuery: (_api: unknown, _args: unknown) => mockLast24h,
 }));
 
 // ── Mutable auth state ──────────────────────────────────────────
@@ -79,6 +82,7 @@ function resetMocks() {
   mockResults = [];
   mockStatus = 'Exhausted';
   mockIsLoading = false;
+  mockLast24h = null;
   mockRouterPush.mockClear();
   mockLoadMore.mockClear();
   currentAuthState = {
@@ -179,36 +183,6 @@ function makeMedicineActivity(overrides?: Partial<Record<string, unknown>>) {
   };
 }
 
-/** Create mock bottle feeds spaced over time for summary card testing. */
-function makeBottleFeedsForSummary() {
-  const now = Date.now();
-  const hour = 3600 * 1000;
-
-  return [
-    {
-      _id: 'feed-latest',
-      _creationTime: now,
-      timestamp: new Date(now - 0.5 * hour).toISOString(), // 30 min ago
-      type: 'feed',
-      feed: { type: 'expressed', volume: { ml: 60 } },
-    },
-    {
-      _id: 'feed-middle',
-      _creationTime: now - 1000,
-      timestamp: new Date(now - 3 * hour).toISOString(), // 3 hours ago
-      type: 'feed',
-      feed: { type: 'expressed', volume: { ml: 90 } },
-    },
-    {
-      _id: 'feed-earliest',
-      _creationTime: now - 2000,
-      timestamp: new Date(now - 5 * hour).toISOString(), // 5 hours ago
-      type: 'feed',
-      feed: { type: 'expressed', volume: { ml: 120 } },
-    },
-  ];
-}
-
 // ── Import page (after all mocks) ────────────────────────────────
 
 import AppHomePage from './page';
@@ -266,88 +240,31 @@ describe('App home page', () => {
     });
   });
 
-  // ── 3. Summary card ───────────────────────────────────────────
+  // ── 3. Last 24h summary card ────────────────────────────────────
 
-  describe('summary card', () => {
-    it('shows summary card when feed activities exist', async () => {
-      mockResults = makeBottleFeedsForSummary();
+  describe('last 24h summary card', () => {
+    const last24hFixture = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 90, total24hMl: 240, bottleCount: 3 },
+      diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
+    };
+
+    it('shows Last24hSummaryCard when query returns hasAny: true', () => {
       mockIsLoading = false;
       mockStatus = 'Exhausted';
-
-      render(<AppHomePage />);
-
-      await waitFor(() => {
-        expect(screen.getByText('Feeding Summary')).toBeInTheDocument();
-      });
-    });
-
-    it('shows "Last Feed" with a time ago label', async () => {
-      mockResults = makeBottleFeedsForSummary();
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-
-      render(<AppHomePage />);
-
-      await waitFor(() => {
-        expect(screen.getByText('Last Feed')).toBeInTheDocument();
-      });
-      // The actual time-ago text will vary, but the label row should be present
-      const lastFeedLabel = screen.getByText('Last Feed');
-      expect(lastFeedLabel).toBeInTheDocument();
-    });
-
-    it('shows "3h Avg" with ml value', async () => {
-      mockResults = makeBottleFeedsForSummary();
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-
-      render(<AppHomePage />);
-
-      await waitFor(() => {
-        expect(screen.getByText('3h Avg')).toBeInTheDocument();
-      });
-      // Should have ml values displayed (use getAllByText since multiple ml values exist)
-      const mlEls = screen.getAllByText(/ml/);
-      expect(mlEls.length).toBeGreaterThan(0);
-    });
-
-    it('shows "24h Total" with ml value', async () => {
-      mockResults = makeBottleFeedsForSummary();
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-
-      render(<AppHomePage />);
-
-      await waitFor(() => {
-        expect(screen.getByText('24h Total')).toBeInTheDocument();
-      });
-    });
-
-    it('does not show summary card when no feed activities exist', async () => {
       mockResults = [
-        makeDiaperActivity({ timestamp: new Date().toISOString() }),
-        makeTemperatureActivity({ timestamp: new Date().toISOString() }),
+        {
+          _id: 'b1',
+          _creationTime: Date.now() - 1000,
+          timestamp: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+          type: 'feed',
+          feed: { type: 'expressed', volume: { ml: 120 } },
+        },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockLast24h = last24hFixture;
 
-      render(<AppHomePage />);
-
-      await waitFor(() => {
-        expect(screen.queryByText('Feeding Summary')).not.toBeInTheDocument();
-      });
-    });
-
-    it('shows the Daily Summary card when any activities exist', async () => {
-      mockResults = makeBottleFeedsForSummary();
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-
-      render(<AppHomePage />);
-
-      await waitFor(() => {
-        expect(screen.getByText(/Feeding Summary/)).toBeInTheDocument();
-      });
+      const { container } = render(<AppHomePage />);
+      expect(container.textContent).toContain('Last 24h');
     });
   });
 
@@ -981,35 +898,29 @@ describe('App home page', () => {
       expect(noRecordsEls.length).toBe(1); // Diapers empty; Medical gone
     });
 
-    it('DOM ordering: today DailySummaryCard appears between day heading and activity Card inside the today group', () => {
-      // With the per-day layout, the card sits BELOW the h3 date heading and ABOVE the
-      // activity list Card within each day group.
-      const now = Date.now();
-      const hour = 3600 * 1000;
+    it('DOM ordering: Last24hSummaryCard appears between quick actions and day group', () => {
+      // The Last24hSummaryCard sits between QuickActionGrid and the day-group cards
+      mockIsLoading = false;
+      mockStatus = 'Exhausted';
       mockResults = [
         {
           _id: 'b1',
-          _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          _creationTime: Date.now() - 1000,
+          timestamp: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockLast24h = {
+        hasAny: true,
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 90, total24hMl: 240, bottleCount: 3 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+      };
 
       render(<AppHomePage />);
 
-      // The today card appears in the page — locate via "Bottle:" text inside it
-      const dailySummaryCard = screen.getByText(/Bottle:/).closest('[data-slot="card"]') as HTMLElement;
-      expect(dailySummaryCard).not.toBeNull();
-
-      // Feeding Summary is a separate rose card at the top of the page, above all day groups.
-      const feedingSummary = screen.getByText('Feeding Summary');
-      // Feeding Summary (top of page) precedes the DailySummaryCard (inside day group)
-      expect(
-        feedingSummary.compareDocumentPosition(dailySummaryCard)
-      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      // Locate the Last 24h header — card should be visible since hasAny: true
+      expect(screen.getByText('Last 24h')).toBeInTheDocument();
     });
 
     // ── New tests for per-day layout ─────────────────────────────────

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -244,12 +244,11 @@ describe('App home page', () => {
 
   describe('last 24h summary card', () => {
     const last24hFixture = {
-      hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
     };
 
-    it('shows Last24hSummaryCard when query returns hasAny: true', () => {
+    it('shows Last24hSummaryCard when query returns data', () => {
       mockIsLoading = false;
       mockStatus = 'Exhausted';
       mockResults = [
@@ -912,14 +911,13 @@ describe('App home page', () => {
         },
       ];
       mockLast24h = {
-        hasAny: true,
         feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
         diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
       };
 
       render(<AppHomePage />);
 
-      // Locate the Last 24h header — card should be visible since hasAny: true
+      // Locate the Last 24h header — card should be visible
       expect(screen.getByText('Last 24h')).toBeInTheDocument();
     });
 

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -245,7 +245,7 @@ describe('App home page', () => {
   describe('last 24h summary card', () => {
     const last24hFixture = {
       hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 90, total24hMl: 240, bottleCount: 3 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
     };
 
@@ -913,7 +913,7 @@ describe('App home page', () => {
       ];
       mockLast24h = {
         hasAny: true,
-        feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 90, total24hMl: 240, bottleCount: 3 },
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
         diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
       };
 

--- a/apps/webapp/src/lib/use-now-bucket.spec.ts
+++ b/apps/webapp/src/lib/use-now-bucket.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { roundUpToNext5Min, useNowBucket5Min } from './use-now-bucket';
+
+describe('roundUpToNext5Min', () => {
+  it('rounds mid-bucket up to next boundary', () => {
+    const result = roundUpToNext5Min(1000);
+    expect(result).toBe(300_000);
+  });
+
+  it('keeps exact boundary unchanged (returns + 5min)', () => {
+    const boundary = 300_000;
+    const result = roundUpToNext5Min(boundary);
+    expect(result).toBe(boundary + 300_000);
+  });
+
+  it('handles large timestamps', () => {
+    const large = 1_735_204_800_000;
+    const result = roundUpToNext5Min(large);
+    expect(result % 300_000).toBe(0);
+    expect(result).toBeGreaterThan(large);
+  });
+});
+
+describe('useNowBucket5Min', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns ISO string with UTC zone', () => {
+    vi.setSystemTime(new Date('2025-01-15T12:03:00.000Z'));
+    const { result } = renderHook(() => useNowBucket5Min());
+    expect(result.current).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$/);
+  });
+});

--- a/apps/webapp/src/lib/use-now-bucket.ts
+++ b/apps/webapp/src/lib/use-now-bucket.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import { DateTime } from 'luxon';
+
+export function roundUpToNext5Min(ms: number): number {
+  const boundary = Math.ceil(ms / 300_000) * 300_000;
+  if (boundary === ms) return ms + 300_000;
+  return boundary;
+}
+
+export function useNowBucket5Min(): string {
+  const [bucket, setBucket] = useState<number>(() => roundUpToNext5Min(Date.now()));
+
+  useEffect(() => {
+    const scheduleNext = () => {
+      const next = roundUpToNext5Min(Date.now());
+      const delay = next - Date.now();
+      const timerId = setTimeout(() => {
+        setBucket(roundUpToNext5Min(Date.now()));
+        scheduleNext();
+      }, Math.max(delay, 0));
+      return timerId;
+    };
+
+    const timerId = scheduleNext();
+    return () => clearTimeout(timerId);
+  }, []);
+
+  return DateTime.fromMillis(bucket, { zone: 'utc' }).toISO()!;
+}

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -106,4 +106,84 @@ describe('Last24hSummaryCard', () => {
     expect(root.className).toMatch(/bg-rose-50/);
     expect(root.className).toMatch(/dark:bg-rose-950/);
   });
+
+  it('hides 3h row when last3hMl is 0 even with bottles in window', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 5 * 3_600_000, last3hMl: 0, total24hMl: 60, bottleCount: 1 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/Last:/)).toBeInTheDocument();
+    expect(screen.queryByText(/3h:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getByText(/60 ml/)).toBeInTheDocument();
+  });
+
+  it('shows 3h row when last3hMl > 0 with a single recent bottle', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/3h:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/60 ml/)).toHaveLength(2);
+  });
+
+  it('renders all diaper kinds in DOM order when all non-zero', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 2, mixed: 1, dirty: 3, total: 6 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    const labels = screen.getAllByText(/^(Wet|Mixed|Dirty):$/);
+    expect(labels).toHaveLength(3);
+    expect(labels[0].textContent).toBe('Wet:');
+    expect(labels[1].textContent).toBe('Mixed:');
+    expect(labels[2].textContent).toBe('Dirty:');
+  });
+
+  it('hides card when hasAny is false even with populated feed/diapers', () => {
+    const summary = {
+      hasAny: false,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
+      diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
+    };
+    const { container } = render(
+      <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('applies font-medium only to volume values, not time-ago', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    const timeAgoEl = screen.getByText(/^\d+h ago$/);
+    expect(timeAgoEl.className).not.toMatch(/font-medium/);
+    expect(timeAgoEl.className).toMatch(/text-foreground/);
+    const vol3h = screen.getByText(/^60 ml$/);
+    expect(vol3h.className).toMatch(/font-medium/);
+    const vol24h = screen.getByText(/^120 ml$/);
+    expect(vol24h.className).toMatch(/font-medium/);
+  });
+
+  it('renders large diaper counts correctly', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 99, mixed: 99, dirty: 99, total: 297 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText('Wet:')).toBeInTheDocument();
+    expect(screen.getByText('Mixed:')).toBeInTheDocument();
+    expect(screen.getByText('Dirty:')).toBeInTheDocument();
+    expect(screen.getAllByText(/^99$/)).toHaveLength(3);
+  });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -9,7 +9,7 @@ beforeEach(() => {
 
 const defaultSummary = {
   hasAny: false,
-  feed: { lastFeedAtMs: null, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+  feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
   diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
 };
 
@@ -24,34 +24,47 @@ describe('Last24hSummaryCard', () => {
   it('renders feed stats correctly with ≥2 bottle feeds', () => {
     const summary = {
       hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 90, total24hMl: 240, bottleCount: 3 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('Last 24h')).toBeInTheDocument();
     expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.getByText(/3h avg:/)).toBeInTheDocument();
+    expect(screen.getByText(/3h:/)).toBeInTheDocument();
     expect(screen.getByText(/90 ml/)).toBeInTheDocument();
     expect(screen.getByText(/24h:/)).toBeInTheDocument();
     expect(screen.getByText(/240 ml/)).toBeInTheDocument();
   });
 
-  it('hides 3h avg / 24h total when bottleCount < 2', () => {
+  it('renders both volume lines when bottleCount === 1', () => {
     const summary = {
       hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 60, bottleCount: 1 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.queryByText(/3h avg:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/3h:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/60 ml/)).toHaveLength(2);
+  });
+
+  it('hides volume lines when bottleCount === 0', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/Last:/)).toBeInTheDocument();
+    expect(screen.queryByText(/3h:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/24h:/)).not.toBeInTheDocument();
   });
 
   it('renders diaper counts excluding zeros', () => {
     const summary = {
       hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 3, dirty: 1, mixed: 0, total: 4 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -63,7 +76,7 @@ describe('Last24hSummaryCard', () => {
   it('shows "No feeds" when lastFeedAtMs is null', () => {
     const summary = {
       hasAny: true,
-      feed: { lastFeedAtMs: null, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -73,7 +86,7 @@ describe('Last24hSummaryCard', () => {
   it('shows "No changes" when no diapers', () => {
     const summary = {
       hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -83,12 +96,12 @@ describe('Last24hSummaryCard', () => {
   it('applies dark mode classes via semantic color tokens', () => {
     const summary = {
       hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
     };
     const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const root = container.firstChild as Element;
-    expect(root.className).toMatch(/bg-indigo-50/);
-    expect(root.className).toMatch(/dark:bg-indigo-950/);
+    expect(root.className).toMatch(/bg-rose-50/);
+    expect(root.className).toMatch(/dark:bg-rose-950/);
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -21,7 +21,19 @@ describe('Last24hSummaryCard', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders feed stats correctly with ≥2 bottle feeds', () => {
+  it('hides card when hasAny is false even with populated feed/diapers', () => {
+    const summary = {
+      hasAny: false,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
+      diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
+    };
+    const { container } = render(
+      <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders feed stats when values are non-zero', () => {
     const summary = {
       hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
@@ -34,105 +46,49 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText(/90 ml/)).toBeInTheDocument();
     expect(screen.getByText(/24h:/)).toBeInTheDocument();
     expect(screen.getByText(/240 ml/)).toBeInTheDocument();
+    expect(screen.getByText(/^\d+h ago$/)).toBeInTheDocument();
   });
 
-  it('renders both volume lines when bottleCount === 1', () => {
-    const summary = {
-      hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1 },
-      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
-    };
-    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.getByText(/3h:/)).toBeInTheDocument();
-    expect(screen.getByText(/24h:/)).toBeInTheDocument();
-    expect(screen.getAllByText(/60 ml/)).toHaveLength(2);
-  });
-
-  it('hides volume lines when bottleCount === 0', () => {
-    const summary = {
-      hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
-      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
-    };
-    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.queryByText(/3h:/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/24h:/)).not.toBeInTheDocument();
-  });
-
-  it('renders diaper counts excluding zeros', () => {
-    const summary = {
-      hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
-      diapers: { wet: 3, dirty: 1, mixed: 0, total: 4 },
-    };
-    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText('Wet:')).toBeInTheDocument();
-    expect(screen.getByText(/^3$/)).toBeInTheDocument();
-    expect(screen.getByText('Dirty:')).toBeInTheDocument();
-    expect(screen.getByText(/^1$/)).toBeInTheDocument();
-    expect(screen.queryByText('Mixed:')).not.toBeInTheDocument();
-  });
-
-  it('shows "No feeds" when lastFeedAtMs is null', () => {
+  it('renders all rows including em-dashes when values are zero or null', () => {
     const summary = {
       hasAny: true,
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText('No feeds')).toBeInTheDocument();
-  });
-
-  it('shows "No changes" when no diapers', () => {
-    const summary = {
-      hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
-      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
-    };
-    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText('No changes')).toBeInTheDocument();
-  });
-
-  it('applies dark mode classes via semantic color tokens', () => {
-    const summary = {
-      hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
-      diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
-    };
-    const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    const root = container.firstChild as Element;
-    expect(root.className).toMatch(/bg-rose-50/);
-    expect(root.className).toMatch(/dark:bg-rose-950/);
-  });
-
-  it('hides 3h row when last3hMl is 0 even with bottles in window', () => {
-    const summary = {
-      hasAny: true,
-      feed: { lastFeedAtMs: Date.now() - 5 * 3_600_000, last3hMl: 0, total24hMl: 60, bottleCount: 1 },
-      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
-    };
-    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.queryByText(/3h:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/3h:/)).toBeInTheDocument();
     expect(screen.getByText(/24h:/)).toBeInTheDocument();
-    expect(screen.getByText(/60 ml/)).toBeInTheDocument();
+    expect(screen.getByText('Wet:')).toBeInTheDocument();
+    expect(screen.getByText('Mixed:')).toBeInTheDocument();
+    expect(screen.getByText('Dirty:')).toBeInTheDocument();
+    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(6);
   });
 
-  it('shows 3h row when last3hMl > 0 with a single recent bottle', () => {
+  it('renders non-zero values alongside em-dashes for zero values', () => {
     const summary = {
       hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1 },
-      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+      diapers: { wet: 2, dirty: 0, mixed: 0, total: 2 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/3h:/)).toBeInTheDocument();
-    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getByText('1h ago')).toBeInTheDocument();
     expect(screen.getAllByText(/60 ml/)).toHaveLength(2);
+    expect(screen.getByText(/^2$/)).toBeInTheDocument();
+    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(2);
   });
 
-  it('renders all diaper kinds in DOM order when all non-zero', () => {
+  it('renders no em-dashes when all values are non-zero', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
+      diapers: { wet: 2, dirty: 1, mixed: 3, total: 6 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.queryByText('\u2014')).not.toBeInTheDocument();
+  });
+
+  it('renders diaper labels in DOM order', () => {
     const summary = {
       hasAny: true,
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
@@ -144,18 +100,6 @@ describe('Last24hSummaryCard', () => {
     expect(labels[0].textContent).toBe('Wet:');
     expect(labels[1].textContent).toBe('Mixed:');
     expect(labels[2].textContent).toBe('Dirty:');
-  });
-
-  it('hides card when hasAny is false even with populated feed/diapers', () => {
-    const summary = {
-      hasAny: false,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
-      diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
-    };
-    const { container } = render(
-      <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
-    );
-    expect(container).toBeEmptyDOMElement();
   });
 
   it('applies font-medium only to volume values, not time-ago', () => {
@@ -185,5 +129,17 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText('Mixed:')).toBeInTheDocument();
     expect(screen.getByText('Dirty:')).toBeInTheDocument();
     expect(screen.getAllByText(/^99$/)).toHaveLength(3);
+  });
+
+  it('applies dark mode classes via semantic color tokens', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+    };
+    const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    const root = container.firstChild as Element;
+    expect(root.className).toMatch(/bg-rose-50/);
+    expect(root.className).toMatch(/dark:bg-rose-950/);
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Last24hSummaryCard } from './Last24hSummaryCard';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+});
+
+const defaultSummary = {
+  hasAny: false,
+  feed: { lastFeedAtMs: null, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+  diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+};
+
+describe('Last24hSummaryCard', () => {
+  it('renders nothing when hasAny is false', () => {
+    const { container } = render(
+      <Last24hSummaryCard summary={defaultSummary} nowMs={Date.now()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders feed stats correctly with ≥2 bottle feeds', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 90, total24hMl: 240, bottleCount: 3 },
+      diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText('Last 24h')).toBeInTheDocument();
+    expect(screen.getByText(/Last:/)).toBeInTheDocument();
+    expect(screen.getByText(/3h avg:/)).toBeInTheDocument();
+    expect(screen.getByText(/90 ml/)).toBeInTheDocument();
+    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getByText(/240 ml/)).toBeInTheDocument();
+  });
+
+  it('hides 3h avg / 24h total when bottleCount < 2', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 60, bottleCount: 1 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/Last:/)).toBeInTheDocument();
+    expect(screen.queryByText(/3h avg:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/24h:/)).not.toBeInTheDocument();
+  });
+
+  it('renders diaper counts excluding zeros', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 3, dirty: 1, mixed: 0, total: 4 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/3 wet/)).toBeInTheDocument();
+    expect(screen.getByText(/1 dirty/)).toBeInTheDocument();
+    expect(screen.queryByText(/mixed/)).not.toBeInTheDocument();
+  });
+
+  it('shows "No feeds" when lastFeedAtMs is null', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: null, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText('No feeds')).toBeInTheDocument();
+  });
+
+  it('shows "No changes" when no diapers', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText('No changes')).toBeInTheDocument();
+  });
+
+  it('applies dark mode classes via semantic color tokens', () => {
+    const summary = {
+      hasAny: true,
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, threeHourAvgMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+    };
+    const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    const root = container.firstChild as Element;
+    expect(root.className).toMatch(/bg-indigo-50/);
+    expect(root.className).toMatch(/dark:bg-indigo-950/);
+  });
+});

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -68,9 +68,11 @@ describe('Last24hSummaryCard', () => {
       diapers: { wet: 3, dirty: 1, mixed: 0, total: 4 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/3 wet/)).toBeInTheDocument();
-    expect(screen.getByText(/1 dirty/)).toBeInTheDocument();
-    expect(screen.queryByText(/mixed/)).not.toBeInTheDocument();
+    expect(screen.getByText('Wet:')).toBeInTheDocument();
+    expect(screen.getByText(/^3$/)).toBeInTheDocument();
+    expect(screen.getByText('Dirty:')).toBeInTheDocument();
+    expect(screen.getByText(/^1$/)).toBeInTheDocument();
+    expect(screen.queryByText('Mixed:')).not.toBeInTheDocument();
   });
 
   it('shows "No feeds" when lastFeedAtMs is null', () => {

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -7,35 +7,27 @@ beforeEach(() => {
   vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
 });
 
-const defaultSummary = {
-  hasAny: false,
-  feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
-  diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
-};
-
 describe('Last24hSummaryCard', () => {
-  it('renders nothing when hasAny is false', () => {
-    const { container } = render(
-      <Last24hSummaryCard summary={defaultSummary} nowMs={Date.now()} />
-    );
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('hides card when hasAny is false even with populated feed/diapers', () => {
+  it('renders all 6 rows even when all values are empty or zero', () => {
     const summary = {
-      hasAny: false,
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
-      diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     const { container } = render(
       <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
     );
-    expect(container).toBeEmptyDOMElement();
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText(/Last:/)).toBeInTheDocument();
+    expect(screen.getByText(/3h:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getByText('Wet:')).toBeInTheDocument();
+    expect(screen.getByText('Mixed:')).toBeInTheDocument();
+    expect(screen.getByText('Dirty:')).toBeInTheDocument();
+    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(6);
   });
 
   it('renders feed stats when values are non-zero', () => {
     const summary = {
-      hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
     };
@@ -49,25 +41,8 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText(/^\d+h ago$/)).toBeInTheDocument();
   });
 
-  it('renders all rows including em-dashes when values are zero or null', () => {
-    const summary = {
-      hasAny: true,
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
-      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
-    };
-    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.getByText(/3h:/)).toBeInTheDocument();
-    expect(screen.getByText(/24h:/)).toBeInTheDocument();
-    expect(screen.getByText('Wet:')).toBeInTheDocument();
-    expect(screen.getByText('Mixed:')).toBeInTheDocument();
-    expect(screen.getByText('Dirty:')).toBeInTheDocument();
-    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(6);
-  });
-
   it('renders non-zero values alongside em-dashes for zero values', () => {
     const summary = {
-      hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1 },
       diapers: { wet: 2, dirty: 0, mixed: 0, total: 2 },
     };
@@ -80,7 +55,6 @@ describe('Last24hSummaryCard', () => {
 
   it('renders no em-dashes when all values are non-zero', () => {
     const summary = {
-      hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
       diapers: { wet: 2, dirty: 1, mixed: 3, total: 6 },
     };
@@ -90,7 +64,6 @@ describe('Last24hSummaryCard', () => {
 
   it('renders diaper labels in DOM order', () => {
     const summary = {
-      hasAny: true,
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 2, mixed: 1, dirty: 3, total: 6 },
     };
@@ -104,7 +77,6 @@ describe('Last24hSummaryCard', () => {
 
   it('applies font-medium only to volume values, not time-ago', () => {
     const summary = {
-      hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
@@ -120,7 +92,6 @@ describe('Last24hSummaryCard', () => {
 
   it('renders large diaper counts correctly', () => {
     const summary = {
-      hasAny: true,
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 99, mixed: 99, dirty: 99, total: 297 },
     };
@@ -133,7 +104,6 @@ describe('Last24hSummaryCard', () => {
 
   it('applies dark mode classes via semantic color tokens', () => {
     const summary = {
-      hasAny: true,
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
       diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
     };

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -33,21 +33,18 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
             <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
             <div className="text-xs text-muted-foreground">
               {feed.lastFeedAtMs !== null ? (
-                <>
-                  <p>Last: {timeAgoFromMs(nowMs - feed.lastFeedAtMs)}</p>
+                <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                  <span>Last:</span>
+                  <span className="text-foreground">{timeAgoFromMs(nowMs - feed.lastFeedAtMs)}</span>
                   {feed.bottleCount >= 1 && (
                     <>
-                      <p>
-                        3h:{' '}
-                        <span className="font-medium text-foreground">{feed.last3hMl} ml</span>
-                      </p>
-                      <p>
-                        24h:{' '}
-                        <span className="font-medium text-foreground">{feed.total24hMl} ml</span>
-                      </p>
+                      <span>3h:</span>
+                      <span className="font-medium text-foreground">{feed.last3hMl} ml</span>
+                      <span>24h:</span>
+                      <span className="font-medium text-foreground">{feed.total24hMl} ml</span>
                     </>
                   )}
-                </>
+                </div>
               ) : (
                 <p className="italic">No feeds</p>
               )}
@@ -61,15 +58,26 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
             <p className="text-xs font-semibold text-foreground mb-0.5">Diapers</p>
             <div className="text-xs text-muted-foreground">
               {diapers.total > 0 ? (
-                <p>
-                  {[
-                    diapers.wet > 0 ? `${diapers.wet} wet` : null,
-                    diapers.mixed > 0 ? `${diapers.mixed} mixed` : null,
-                    diapers.dirty > 0 ? `${diapers.dirty} dirty` : null,
-                  ]
-                    .filter(Boolean)
-                    .join(' · ')}
-                </p>
+                <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                  {diapers.wet > 0 && (
+                    <>
+                      <span>Wet:</span>
+                      <span className="font-medium text-foreground">{diapers.wet}</span>
+                    </>
+                  )}
+                  {diapers.mixed > 0 && (
+                    <>
+                      <span>Mixed:</span>
+                      <span className="font-medium text-foreground">{diapers.mixed}</span>
+                    </>
+                  )}
+                  {diapers.dirty > 0 && (
+                    <>
+                      <span>Dirty:</span>
+                      <span className="font-medium text-foreground">{diapers.dirty}</span>
+                    </>
+                  )}
+                </div>
               ) : (
                 <p className="italic">No changes</p>
               )}

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -18,28 +18,28 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
   const { feed, diapers } = summary;
 
   return (
-    <div className="bg-indigo-50/60 dark:bg-indigo-950/20 border border-indigo-200 dark:border-indigo-900 rounded-lg mb-6">
+    <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
       <div className="flex items-center gap-1.5 px-4 pt-2 pb-1">
-        <Clock className="h-3.5 w-3.5 text-indigo-600 dark:text-indigo-400" />
-        <span className="text-xs font-semibold text-indigo-900 dark:text-indigo-200 uppercase tracking-wide">
+        <Clock className="h-3.5 w-3.5 text-rose-600 dark:text-rose-400" />
+        <span className="text-xs font-semibold text-rose-900 dark:text-rose-200 uppercase tracking-wide">
           Last 24h
         </span>
       </div>
 
       <div className="grid grid-cols-2 gap-3 px-4 pb-2">
         <div className="flex items-start gap-2">
-          <Milk className="h-3 w-3 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+          <Milk className="h-3 w-3 text-rose-600 dark:text-rose-400 flex-shrink-0 mt-0.5" />
           <div className="min-w-0 flex-1">
             <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
             <div className="text-xs text-muted-foreground">
               {feed.lastFeedAtMs !== null ? (
                 <>
                   <p>Last: {timeAgoFromMs(nowMs - feed.lastFeedAtMs)}</p>
-                  {feed.bottleCount >= 2 && (
+                  {feed.bottleCount >= 1 && (
                     <>
                       <p>
-                        3h avg:{' '}
-                        <span className="font-medium text-foreground">{feed.threeHourAvgMl} ml</span>
+                        3h:{' '}
+                        <span className="font-medium text-foreground">{feed.last3hMl} ml</span>
                       </p>
                       <p>
                         24h:{' '}
@@ -56,7 +56,7 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
         </div>
 
         <div className="flex items-start gap-2">
-          <Baby className="h-3 w-3 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+          <Baby className="h-3 w-3 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
           <div className="min-w-0 flex-1">
             <p className="text-xs font-semibold text-foreground mb-0.5">Diapers</p>
             <div className="text-xs text-muted-foreground">

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -36,10 +36,14 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
                 <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
                   <span>Last:</span>
                   <span className="text-foreground">{timeAgoFromMs(nowMs - feed.lastFeedAtMs)}</span>
-                  {feed.bottleCount >= 1 && (
+                  {feed.last3hMl > 0 && (
                     <>
                       <span>3h:</span>
                       <span className="font-medium text-foreground">{feed.last3hMl} ml</span>
+                    </>
+                  )}
+                  {feed.bottleCount >= 1 && (
+                    <>
                       <span>24h:</span>
                       <span className="font-medium text-foreground">{feed.total24hMl} ml</span>
                     </>

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -15,8 +15,6 @@ interface Last24hSummaryCardProps {
 }
 
 export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) {
-  if (!summary.hasAny) return null;
-
   const { feed, diapers } = summary;
 
   return (

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -5,6 +5,8 @@ import { timeAgoFromMs } from '@/lib/activity-form-utils';
 import type { FunctionReturnType } from 'convex/server';
 import { api } from '@workspace/backend/convex/_generated/api';
 
+const DASH = '\u2014';
+
 type Last24hSummary = FunctionReturnType<typeof api.web.babyTracker.activities.getLast24hSummary>;
 
 interface Last24hSummaryCardProps {
@@ -32,26 +34,20 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
           <div className="min-w-0 flex-1">
             <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
             <div className="text-xs text-muted-foreground">
-              {feed.lastFeedAtMs !== null ? (
-                <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
-                  <span>Last:</span>
-                  <span className="text-foreground">{timeAgoFromMs(nowMs - feed.lastFeedAtMs)}</span>
-                  {feed.last3hMl > 0 && (
-                    <>
-                      <span>3h:</span>
-                      <span className="font-medium text-foreground">{feed.last3hMl} ml</span>
-                    </>
-                  )}
-                  {feed.bottleCount >= 1 && (
-                    <>
-                      <span>24h:</span>
-                      <span className="font-medium text-foreground">{feed.total24hMl} ml</span>
-                    </>
-                  )}
-                </div>
-              ) : (
-                <p className="italic">No feeds</p>
-              )}
+              <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                <span>Last:</span>
+                <span className="text-foreground">
+                  {feed.lastFeedAtMs !== null ? timeAgoFromMs(nowMs - feed.lastFeedAtMs) : DASH}
+                </span>
+                <span>3h:</span>
+                <span className="font-medium text-foreground">
+                  {feed.last3hMl > 0 ? `${feed.last3hMl} ml` : DASH}
+                </span>
+                <span>24h:</span>
+                <span className="font-medium text-foreground">
+                  {feed.bottleCount >= 1 ? `${feed.total24hMl} ml` : DASH}
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -61,30 +57,14 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
           <div className="min-w-0 flex-1">
             <p className="text-xs font-semibold text-foreground mb-0.5">Diapers</p>
             <div className="text-xs text-muted-foreground">
-              {diapers.total > 0 ? (
-                <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
-                  {diapers.wet > 0 && (
-                    <>
-                      <span>Wet:</span>
-                      <span className="font-medium text-foreground">{diapers.wet}</span>
-                    </>
-                  )}
-                  {diapers.mixed > 0 && (
-                    <>
-                      <span>Mixed:</span>
-                      <span className="font-medium text-foreground">{diapers.mixed}</span>
-                    </>
-                  )}
-                  {diapers.dirty > 0 && (
-                    <>
-                      <span>Dirty:</span>
-                      <span className="font-medium text-foreground">{diapers.dirty}</span>
-                    </>
-                  )}
-                </div>
-              ) : (
-                <p className="italic">No changes</p>
-              )}
+              <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                <span>Wet:</span>
+                <span className="font-medium text-foreground">{diapers.wet > 0 ? diapers.wet : DASH}</span>
+                <span>Mixed:</span>
+                <span className="font-medium text-foreground">{diapers.mixed > 0 ? diapers.mixed : DASH}</span>
+                <span>Dirty:</span>
+                <span className="font-medium text-foreground">{diapers.dirty > 0 ? diapers.dirty : DASH}</span>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Milk, Baby, Clock } from 'lucide-react';
+import { timeAgoFromMs } from '@/lib/activity-form-utils';
+import type { FunctionReturnType } from 'convex/server';
+import { api } from '@workspace/backend/convex/_generated/api';
+
+type Last24hSummary = FunctionReturnType<typeof api.web.babyTracker.activities.getLast24hSummary>;
+
+interface Last24hSummaryCardProps {
+  summary: Last24hSummary;
+  nowMs: number;
+}
+
+export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) {
+  if (!summary.hasAny) return null;
+
+  const { feed, diapers } = summary;
+
+  return (
+    <div className="bg-indigo-50/60 dark:bg-indigo-950/20 border border-indigo-200 dark:border-indigo-900 rounded-lg mb-6">
+      <div className="flex items-center gap-1.5 px-4 pt-2 pb-1">
+        <Clock className="h-3.5 w-3.5 text-indigo-600 dark:text-indigo-400" />
+        <span className="text-xs font-semibold text-indigo-900 dark:text-indigo-200 uppercase tracking-wide">
+          Last 24h
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 px-4 pb-2">
+        <div className="flex items-start gap-2">
+          <Milk className="h-3 w-3 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
+            <div className="text-xs text-muted-foreground">
+              {feed.lastFeedAtMs !== null ? (
+                <>
+                  <p>Last: {timeAgoFromMs(nowMs - feed.lastFeedAtMs)}</p>
+                  {feed.bottleCount >= 2 && (
+                    <>
+                      <p>
+                        3h avg:{' '}
+                        <span className="font-medium text-foreground">{feed.threeHourAvgMl} ml</span>
+                      </p>
+                      <p>
+                        24h:{' '}
+                        <span className="font-medium text-foreground">{feed.total24hMl} ml</span>
+                      </p>
+                    </>
+                  )}
+                </>
+              ) : (
+                <p className="italic">No feeds</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <Baby className="h-3 w-3 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold text-foreground mb-0.5">Diapers</p>
+            <div className="text-xs text-muted-foreground">
+              {diapers.total > 0 ? (
+                <p>
+                  {[
+                    diapers.wet > 0 ? `${diapers.wet} wet` : null,
+                    diapers.mixed > 0 ? `${diapers.mixed} mixed` : null,
+                    diapers.dirty > 0 ? `${diapers.dirty} dirty` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </p>
+              ) : (
+                <p className="italic">No changes</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -7,6 +7,8 @@ import { v } from 'convex/values';
 import { paginationOptsValidator } from 'convex/server';
 import { SessionIdArg } from 'convex-helpers/server/sessions';
 import { mutation, query } from '../../_generated/server';
+import { ConvexError } from 'convex/values';
+import { DateTime } from 'luxon';
 import { ConvexWebActivityRepository } from '../../../src/infra/ConvexWebActivityRepository';
 import {
   createActivity as createActivityUseCase,
@@ -14,6 +16,7 @@ import {
   deleteActivity as deleteActivityUseCase,
   getActivityById as getActivityByIdUseCase,
   getActivities as getActivitiesUseCase,
+  getLast24hSummary as getLast24hSummaryUseCase,
 } from '../../../src/domain/usecases/activity';
 import { requireAuthAndFamily } from './helpers';
 
@@ -161,5 +164,26 @@ export const getByTimestampDescPaginated = query({
     const { userId, activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
     const repo = new ConvexWebActivityRepository(ctx, activityStreamId);
     return await getActivitiesUseCase(repo, userId.toString(), args.paginationOpts);
+  },
+});
+
+/**
+ * Get a summary of all feed and diaper activities from the last 24 hours.
+ * The nowIso argument is rounded to the nearest 5-min bucket by the client
+ * using useNowBucket5Min(), so Convex can memoize the result per bucket.
+ */
+export const getLast24hSummary = query({
+  args: {
+    ...SessionIdArg,
+    nowIso: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
+    const repo = new ConvexWebActivityRepository(ctx, activityStreamId);
+    const nowMs = DateTime.fromISO(args.nowIso).toMillis();
+    if (!Number.isFinite(nowMs)) {
+      throw new ConvexError({ code: 'BAD_REQUEST', message: 'Invalid nowIso' });
+    }
+    return await getLast24hSummaryUseCase(repo, nowMs);
   },
 });

--- a/services/backend/src/domain/repositories/IActivityRepository.ts
+++ b/services/backend/src/domain/repositories/IActivityRepository.ts
@@ -44,4 +44,15 @@ export interface IActivityRepository {
     deviceId: string,
     paginationOpts: PaginationOpts
   ): Promise<PaginationResult<Activity>>;
+
+  /**
+   * List activities whose timestamp falls within [fromIso, toIso] (inclusive),
+   * ordered by timestamp ascending. Returns ALL matching activities (no pagination).
+   * Intended for bounded windows like "last 24h".
+   */
+  listByTimestampRange(
+    deviceId: string,
+    fromIso: string,
+    toIso: string
+  ): Promise<Activity[]>;
 }

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
@@ -196,4 +196,123 @@ describe('computeLast24hSummary', () => {
       expect(result.hasAny).toBe(true);
     });
   });
+
+  describe('order independence', () => {
+    it('produces same result regardless of input order', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activitiesSorted = [
+        makeFeed('2025-01-15T10:00:00.000Z', 'expressed', { volume: { ml: 90 } }),
+        makeFeed('2025-01-15T11:00:00.000Z', 'formula', { volume: { ml: 70 } }),
+        makeDiaper('2025-01-15T10:00:00.000Z', 'wet'),
+      ];
+      const activitiesShuffled = [
+        makeDiaper('2025-01-15T10:00:00.000Z', 'wet'),
+        makeFeed('2025-01-15T11:00:00.000Z', 'formula', { volume: { ml: 70 } }),
+        makeFeed('2025-01-15T10:00:00.000Z', 'expressed', { volume: { ml: 90 } }),
+      ];
+      const resultSorted = computeLast24hSummary(activitiesSorted, Date.now());
+      const resultShuffled = computeLast24hSummary(activitiesShuffled, Date.now());
+      expect(resultShuffled).toEqual(resultSorted);
+    });
+  });
+
+  describe('duplicate timestamps', () => {
+    it('counts both bottles at the same timestamp', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const ts = '2025-01-15T08:00:00.000Z';
+      const activities = [
+        makeFeed(ts, 'expressed', { volume: { ml: 60 } }),
+        makeFeed(ts, 'formula', { volume: { ml: 90 } }),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.bottleCount).toBe(2);
+      expect(result.feed.total24hMl).toBe(150);
+      expect(result.feed.lastFeedAtMs).toBe(Date.parse(ts));
+    });
+  });
+
+  describe('mixed feed types — lastFeedAtMs', () => {
+    it('picks latest feed regardless of type (latch more recent than bottle)', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const breastTs = '2025-01-15T11:58:00.000Z';  // 2 min ago
+      const bottleTs = '2025-01-15T11:55:00.000Z';   // 5 min ago
+      const activities = [
+        makeFeed(bottleTs, 'expressed', { volume: { ml: 60 } }),
+        makeFeed(breastTs, 'latch', { duration: { left: { seconds: 300 }, right: { seconds: 200 } } }),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.lastFeedAtMs).toBe(Date.parse(breastTs));
+      expect(result.feed.bottleCount).toBe(1);
+      expect(result.feed.total24hMl).toBe(60);
+    });
+  });
+
+  describe('zero-volume bottle', () => {
+    it('counts 0-ml bottle in bottleCount but contributes 0 to volumes', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeFeed('2025-01-15T08:00:00.000Z', 'expressed', { volume: { ml: 0 } }),
+        makeFeed('2025-01-15T09:00:00.000Z', 'formula', { volume: { ml: 90 } }),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.bottleCount).toBe(2);
+      expect(result.feed.total24hMl).toBe(90);
+      expect(result.feed.last3hMl).toBe(0);
+    });
+  });
+
+  describe('future-timestamped activity', () => {
+    it('is excluded from all aggregates', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const futureTs = '2025-01-15T13:00:00.000Z';
+      const activities = [
+        makeFeed('2025-01-15T08:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
+        makeFeed(futureTs, 'formula', { volume: { ml: 90 } }),
+        makeDiaper(futureTs, 'wet'),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.bottleCount).toBe(1);
+      expect(result.feed.total24hMl).toBe(60);
+      expect(result.diapers.total).toBe(0);
+    });
+  });
+
+  describe('composite input', () => {
+    it('counts feed and diaper, ignores medical, sets hasAny true', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeFeed('2025-01-15T08:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
+        makeDiaper('2025-01-15T09:00:00.000Z', 'wet'),
+        makeTemp('2025-01-15T10:00:00.000Z', 37.5),
+        makeDiaper('2025-01-15T11:00:00.000Z', 'dirty'),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.hasAny).toBe(true);
+      expect(result.feed.bottleCount).toBe(1);
+      expect(result.feed.total24hMl).toBe(60);
+      expect(result.diapers.wet).toBe(1);
+      expect(result.diapers.dirty).toBe(1);
+      expect(result.diapers.mixed).toBe(0);
+      expect(result.diapers.total).toBe(2);
+    });
+  });
+
+  describe('diapers only', () => {
+    it('returns hasAny true with feed fields zeroed when only diapers present', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeDiaper('2025-01-15T08:00:00.000Z', 'wet'),
+        makeDiaper('2025-01-15T09:00:00.000Z', 'mixed'),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.hasAny).toBe(true);
+      expect(result.feed.lastFeedAtMs).toBeNull();
+      expect(result.feed.last3hMl).toBe(0);
+      expect(result.feed.total24hMl).toBe(0);
+      expect(result.feed.bottleCount).toBe(0);
+      expect(result.diapers.wet).toBe(1);
+      expect(result.diapers.mixed).toBe(1);
+      expect(result.diapers.total).toBe(2);
+    });
+  });
 });

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
@@ -23,10 +23,9 @@ describe('computeLast24hSummary', () => {
   });
 
   describe('empty input', () => {
-    it('returns hasAny: false with all zeros and null lastFeedAtMs', () => {
+    it('returns all zeros and null lastFeedAtMs for empty input', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
       const result = computeLast24hSummary([], Date.now());
-      expect(result.hasAny).toBe(false);
       expect(result.feed.lastFeedAtMs).toBeNull();
       expect(result.feed.last3hMl).toBe(0);
       expect(result.feed.total24hMl).toBe(0);
@@ -44,7 +43,6 @@ describe('computeLast24hSummary', () => {
       const ts = '2025-01-15T08:00:00.000Z';
       const activities = [makeFeed(ts, 'expressed', { volume: { ml: 60 } })];
       const result = computeLast24hSummary(activities, Date.now());
-      expect(result.hasAny).toBe(true);
       expect(result.feed.lastFeedAtMs).toBe(Date.parse(ts));
       expect(result.feed.last3hMl).toBe(0);  // 4h ago, outside 3h window
       expect(result.feed.total24hMl).toBe(60);
@@ -118,7 +116,6 @@ describe('computeLast24hSummary', () => {
         makeDiaper(outside, 'wet'),
       ];
       const result = computeLast24hSummary(activities, Date.now());
-      expect(result.hasAny).toBe(true);
       expect(result.feed.bottleCount).toBe(1);
       expect(result.feed.total24hMl).toBe(60);
       expect(result.diapers.total).toBe(0);
@@ -179,21 +176,20 @@ describe('computeLast24hSummary', () => {
   });
 
   describe('medical activities', () => {
-    it('are ignored (hasAny stays false if only medical)', () => {
+    it('are ignored (all zeroes if only medical)', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
       const activities = [makeTemp('2025-01-15T08:00:00.000Z', 37.5)];
       const result = computeLast24hSummary(activities, Date.now());
-      expect(result.hasAny).toBe(false);
     });
 
-    it('hasAny is true when medical + feed present', () => {
+    it('produces feed volumes when medical + feed present', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
       const activities = [
         makeTemp('2025-01-15T08:00:00.000Z', 37.5),
         makeFeed('2025-01-15T09:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
       ];
       const result = computeLast24hSummary(activities, Date.now());
-      expect(result.hasAny).toBe(true);
+      expect(result.feed.bottleCount).toBe(1);
     });
   });
 
@@ -278,7 +274,7 @@ describe('computeLast24hSummary', () => {
   });
 
   describe('composite input', () => {
-    it('counts feed and diaper, ignores medical, sets hasAny true', () => {
+    it('counts feed and diaper, ignores medical', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
       const activities = [
         makeFeed('2025-01-15T08:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
@@ -287,7 +283,6 @@ describe('computeLast24hSummary', () => {
         makeDiaper('2025-01-15T11:00:00.000Z', 'dirty'),
       ];
       const result = computeLast24hSummary(activities, Date.now());
-      expect(result.hasAny).toBe(true);
       expect(result.feed.bottleCount).toBe(1);
       expect(result.feed.total24hMl).toBe(60);
       expect(result.diapers.wet).toBe(1);
@@ -298,14 +293,13 @@ describe('computeLast24hSummary', () => {
   });
 
   describe('diapers only', () => {
-    it('returns hasAny true with feed fields zeroed when only diapers present', () => {
+    it('returns feed fields zeroed when only diapers present', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
       const activities = [
         makeDiaper('2025-01-15T08:00:00.000Z', 'wet'),
         makeDiaper('2025-01-15T09:00:00.000Z', 'mixed'),
       ];
       const result = computeLast24hSummary(activities, Date.now());
-      expect(result.hasAny).toBe(true);
       expect(result.feed.lastFeedAtMs).toBeNull();
       expect(result.feed.last3hMl).toBe(0);
       expect(result.feed.total24hMl).toBe(0);

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { computeLast24hSummary, type Last24hSummary } from './ComputeLast24hSummary';
+
+function makeFeed(ts: string, subType: string, extras: Record<string, unknown> = {}) {
+  return { type: 'feed' as const, timestamp: ts, feed: { type: subType, ...extras } };
+}
+
+function makeDiaper(ts: string, diaperType: string) {
+  return { type: 'diaper_change' as const, timestamp: ts, diaperChange: { type: diaperType } };
+}
+
+function makeTemp(ts: string, value: number) {
+  return { type: 'medical' as const, timestamp: ts, medical: { type: 'temperature' as const, temperature: { value } } };
+}
+
+describe('computeLast24hSummary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('empty input', () => {
+    it('returns hasAny: false with all zeros and null lastFeedAtMs', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const result = computeLast24hSummary([], Date.now());
+      expect(result.hasAny).toBe(false);
+      expect(result.feed.lastFeedAtMs).toBeNull();
+      expect(result.feed.threeHourAvgMl).toBe(0);
+      expect(result.feed.total24hMl).toBe(0);
+      expect(result.feed.bottleCount).toBe(0);
+      expect(result.diapers.wet).toBe(0);
+      expect(result.diapers.dirty).toBe(0);
+      expect(result.diapers.mixed).toBe(0);
+      expect(result.diapers.total).toBe(0);
+    });
+  });
+
+  describe('single feed inside window', () => {
+    it('sets lastFeedAtMs, threeHourAvgMl is 0 (need >= 2)', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const ts = '2025-01-15T08:00:00.000Z';
+      const activities = [makeFeed(ts, 'expressed', { volume: { ml: 60 } })];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.hasAny).toBe(true);
+      expect(result.feed.lastFeedAtMs).toBe(Date.parse(ts));
+      expect(result.feed.threeHourAvgMl).toBe(0);
+      expect(result.feed.total24hMl).toBe(60);
+      expect(result.feed.bottleCount).toBe(1);
+    });
+  });
+
+  describe('2+ bottle feeds → extrapolation formula', () => {
+    it('matches old computeSummaryStats extrapolation', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const now = Date.now();
+      const t1 = '2025-01-15T06:00:00.000Z'; // 6h ago, 80ml
+      const t2 = '2025-01-15T08:00:00.000Z'; // 4h ago, 90ml
+      const t3 = '2025-01-15T10:00:00.000Z'; // 2h ago, 70ml
+      const activities = [
+        makeFeed(t1, 'expressed', { volume: { ml: 80 } }),
+        makeFeed(t2, 'formula', { volume: { ml: 90 } }),
+        makeFeed(t3, 'expressed', { volume: { ml: 70 } }),
+      ];
+      const result = computeLast24hSummary(activities, now);
+
+      expect(result.hasAny).toBe(true);
+      expect(result.feed.bottleCount).toBe(3);
+      expect(result.feed.total24hMl).toBe(240);
+
+      const latest = { dateMs: Date.parse(t3), volumeMl: 70 };
+      const earliest = { dateMs: Date.parse(t1), volumeMl: 80 };
+      const totalVol = 240;
+      const totalDurationMins = (latest.dateMs - earliest.dateMs) / (60 * 1000);
+      const minutelyVolume = (totalVol - latest.volumeMl) / totalDurationMins;
+      const expected3h = Math.ceil(minutelyVolume * 60 * 3);
+      expect(result.feed.threeHourAvgMl).toBe(expected3h);
+    });
+
+    it('returns 0 for threeHourAvgMl when only 1 bottle feed', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeFeed('2025-01-15T08:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
+        makeFeed('2025-01-15T08:00:00.000Z', 'latch', { duration: { left: { seconds: 300 }, right: { seconds: 200 } } }),
+      ];
+      expect(computeLast24hSummary(activities, Date.now()).feed.threeHourAvgMl).toBe(0);
+    });
+  });
+
+  describe('activities outside window', () => {
+    it('are excluded', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const inside = '2025-01-15T08:00:00.000Z';
+      const outside = '2025-01-13T08:00:00.000Z';
+      const activities = [
+        makeFeed(inside, 'expressed', { volume: { ml: 60 } }),
+        makeFeed(outside, 'formula', { volume: { ml: 90 } }),
+        makeDiaper(outside, 'wet'),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.hasAny).toBe(true);
+      expect(result.feed.bottleCount).toBe(1);
+      expect(result.feed.total24hMl).toBe(60);
+      expect(result.diapers.total).toBe(0);
+    });
+  });
+
+  describe('diaper counts', () => {
+    it('counts wet, dirty, mixed correctly', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeDiaper('2025-01-15T06:00:00.000Z', 'wet'),
+        makeDiaper('2025-01-15T07:00:00.000Z', 'dirty'),
+        makeDiaper('2025-01-15T08:00:00.000Z', 'mixed'),
+        makeDiaper('2025-01-15T09:00:00.000Z', 'wet'),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.diapers.wet).toBe(2);
+      expect(result.diapers.dirty).toBe(1);
+      expect(result.diapers.mixed).toBe(1);
+      expect(result.diapers.total).toBe(4);
+    });
+  });
+
+  describe('mixed feed types (latch + bottles)', () => {
+    it('only bottles contribute to volume/count', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeFeed('2025-01-15T06:00:00.000Z', 'latch', { duration: { left: { seconds: 300 }, right: { seconds: 200 } } }),
+        makeFeed('2025-01-15T07:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
+        makeFeed('2025-01-15T08:00:00.000Z', 'formula', { volume: { ml: 90 } }),
+        makeFeed('2025-01-15T09:00:00.000Z', 'water', { volume: { ml: 10 } }),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.bottleCount).toBe(3);
+      expect(result.feed.total24hMl).toBe(160);
+      expect(result.feed.threeHourAvgMl).toBeGreaterThan(0);
+    });
+  });
+
+  describe('window boundaries', () => {
+    it('excludes activity exactly 24h ago, includes most-recent', () => {
+      vi.useRealTimers();
+      const now = new Date('2025-01-15T12:00:00.000Z').getTime();
+      const justInside = new Date(now - 1).toISOString();
+      const exactly24hAgo = new Date(now - 24 * 60 * 60 * 1000).toISOString();
+      const justOutside = new Date(now - 24 * 60 * 60 * 1000 - 1).toISOString();
+
+      const activities = [
+        makeFeed(justInside, 'expressed', { volume: { ml: 60 } }),
+        makeFeed(exactly24hAgo, 'formula', { volume: { ml: 90 } }),
+        makeFeed(justOutside, 'expressed', { volume: { ml: 30 } }),
+      ];
+
+      const result = computeLast24hSummary(activities, now);
+      expect(result.feed.bottleCount).toBe(1);
+      expect(result.feed.total24hMl).toBe(60);
+    });
+  });
+
+  describe('medical activities', () => {
+    it('are ignored (hasAny stays false if only medical)', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [makeTemp('2025-01-15T08:00:00.000Z', 37.5)];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.hasAny).toBe(false);
+    });
+
+    it('hasAny is true when medical + feed present', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeTemp('2025-01-15T08:00:00.000Z', 37.5),
+        makeFeed('2025-01-15T09:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.hasAny).toBe(true);
+    });
+  });
+});

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
@@ -28,7 +28,7 @@ describe('computeLast24hSummary', () => {
       const result = computeLast24hSummary([], Date.now());
       expect(result.hasAny).toBe(false);
       expect(result.feed.lastFeedAtMs).toBeNull();
-      expect(result.feed.threeHourAvgMl).toBe(0);
+      expect(result.feed.last3hMl).toBe(0);
       expect(result.feed.total24hMl).toBe(0);
       expect(result.feed.bottleCount).toBe(0);
       expect(result.diapers.wet).toBe(0);
@@ -39,53 +39,71 @@ describe('computeLast24hSummary', () => {
   });
 
   describe('single feed inside window', () => {
-    it('sets lastFeedAtMs, threeHourAvgMl is 0 (need >= 2)', () => {
+    it('sets lastFeedAtMs and total24hMl', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
       const ts = '2025-01-15T08:00:00.000Z';
       const activities = [makeFeed(ts, 'expressed', { volume: { ml: 60 } })];
       const result = computeLast24hSummary(activities, Date.now());
       expect(result.hasAny).toBe(true);
       expect(result.feed.lastFeedAtMs).toBe(Date.parse(ts));
-      expect(result.feed.threeHourAvgMl).toBe(0);
+      expect(result.feed.last3hMl).toBe(0);  // 4h ago, outside 3h window
       expect(result.feed.total24hMl).toBe(60);
       expect(result.feed.bottleCount).toBe(1);
     });
   });
 
-  describe('2+ bottle feeds → extrapolation formula', () => {
-    it('matches old computeSummaryStats extrapolation', () => {
+  describe('last3hMl — real sum of last 3 hours', () => {
+    it('is 0 when no bottle feeds in last 3h', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
-      const now = Date.now();
-      const t1 = '2025-01-15T06:00:00.000Z'; // 6h ago, 80ml
-      const t2 = '2025-01-15T08:00:00.000Z'; // 4h ago, 90ml
-      const t3 = '2025-01-15T10:00:00.000Z'; // 2h ago, 70ml
       const activities = [
-        makeFeed(t1, 'expressed', { volume: { ml: 80 } }),
-        makeFeed(t2, 'formula', { volume: { ml: 90 } }),
-        makeFeed(t3, 'expressed', { volume: { ml: 70 } }),
+        makeFeed('2025-01-15T06:00:00.000Z', 'expressed', { volume: { ml: 80 } }), // 6h ago
+        makeFeed('2025-01-15T08:00:00.000Z', 'formula', { volume: { ml: 90 } }),   // 4h ago
       ];
-      const result = computeLast24hSummary(activities, now);
-
-      expect(result.hasAny).toBe(true);
-      expect(result.feed.bottleCount).toBe(3);
-      expect(result.feed.total24hMl).toBe(240);
-
-      const latest = { dateMs: Date.parse(t3), volumeMl: 70 };
-      const earliest = { dateMs: Date.parse(t1), volumeMl: 80 };
-      const totalVol = 240;
-      const totalDurationMins = (latest.dateMs - earliest.dateMs) / (60 * 1000);
-      const minutelyVolume = (totalVol - latest.volumeMl) / totalDurationMins;
-      const expected3h = Math.ceil(minutelyVolume * 60 * 3);
-      expect(result.feed.threeHourAvgMl).toBe(expected3h);
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.last3hMl).toBe(0);  // both outside 3h window
+      expect(result.feed.total24hMl).toBe(170);
     });
 
-    it('returns 0 for threeHourAvgMl when only 1 bottle feed', () => {
+    it('sums bottles inside 3h window and excludes those 3h-24h ago', () => {
       vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
       const activities = [
-        makeFeed('2025-01-15T08:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
-        makeFeed('2025-01-15T08:00:00.000Z', 'latch', { duration: { left: { seconds: 300 }, right: { seconds: 200 } } }),
+        makeFeed('2025-01-15T06:00:00.000Z', 'expressed', { volume: { ml: 80 } }), // 6h ago
+        makeFeed('2025-01-15T10:00:00.000Z', 'formula', { volume: { ml: 90 } }),   // 2h ago
+        makeFeed('2025-01-15T11:00:00.000Z', 'expressed', { volume: { ml: 70 } }), // 1h ago
       ];
-      expect(computeLast24hSummary(activities, Date.now()).feed.threeHourAvgMl).toBe(0);
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.total24hMl).toBe(240);
+      expect(result.feed.last3hMl).toBe(160);  // 90 + 70 (within 3h)
+    });
+
+    it('excludes breastfeed / solids from last3hMl', () => {
+      vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
+      const activities = [
+        makeFeed('2025-01-15T11:00:00.000Z', 'latch', { duration: { left: { seconds: 300 }, right: { seconds: 200 } } }),
+        makeFeed('2025-01-15T10:30:00.000Z', 'solids', { description: 'carrots' }),
+      ];
+      const result = computeLast24hSummary(activities, Date.now());
+      expect(result.feed.last3hMl).toBe(0);
+      expect(result.feed.total24hMl).toBe(0);
+      expect(result.feed.bottleCount).toBe(0);
+    });
+
+    it('is exclusive on the 3h boundary (tsMs > nowMs - 3h)', () => {
+      vi.useRealTimers();
+      const now = new Date('2025-01-15T12:00:00.000Z').getTime();
+      const justInside = new Date(now - 3 * 60 * 60 * 1000 + 1).toISOString();  // 2h 59m 59s ago
+      const exactly3hAgo = new Date(now - 3 * 60 * 60 * 1000).toISOString();   // exactly 3h ago
+      const justOutside = new Date(now - 3 * 60 * 60 * 1000 - 1).toISOString(); // 3h 1ms ago
+
+      const activities = [
+        makeFeed(justInside, 'expressed', { volume: { ml: 60 } }),
+        makeFeed(exactly3hAgo, 'formula', { volume: { ml: 90 } }),
+        makeFeed(justOutside, 'expressed', { volume: { ml: 30 } }),
+      ];
+
+      const result = computeLast24hSummary(activities, now);
+      expect(result.feed.last3hMl).toBe(60);  // only justInside counts
+      expect(result.feed.total24hMl).toBe(180);
     });
   });
 
@@ -136,7 +154,7 @@ describe('computeLast24hSummary', () => {
       const result = computeLast24hSummary(activities, Date.now());
       expect(result.feed.bottleCount).toBe(3);
       expect(result.feed.total24hMl).toBe(160);
-      expect(result.feed.threeHourAvgMl).toBeGreaterThan(0);
+      expect(result.feed.last3hMl).toBe(0); // expressed/formula/water at 7-9h are outside 3h window
     });
   });
 

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
@@ -1,0 +1,105 @@
+import type { Activity } from '../../activity/Activity';
+import type { BottleFeedType } from '../../activity/Activity';
+
+export interface Last24hSummary {
+  hasAny: boolean;
+  feed: {
+    lastFeedAtMs: number | null;
+    threeHourAvgMl: number;
+    total24hMl: number;
+    bottleCount: number;
+  };
+  diapers: {
+    wet: number;
+    dirty: number;
+    mixed: number;
+    total: number;
+  };
+}
+
+const BOTTLE_TYPES: BottleFeedType[] = ['expressed', 'formula', 'water'];
+
+export function computeLast24hSummary(
+  activities: ReadonlyArray<Activity>,
+  nowMs: number
+): Last24hSummary {
+  const windowStartMs = nowMs - 24 * 60 * 60 * 1000;
+
+  let lastFeedAtMs: number | null = null;
+  let total24hMl = 0;
+  let bottleCount = 0;
+  let wet = 0;
+  let dirty = 0;
+  let mixed = 0;
+  let hasAny = false;
+
+  for (const activity of activities) {
+    const tsMs = Date.parse(activity.timestamp);
+    if (tsMs <= nowMs && tsMs > windowStartMs) {
+      if (activity.type === 'feed') {
+        hasAny = true;
+        if (tsMs > (lastFeedAtMs ?? 0)) {
+          lastFeedAtMs = tsMs;
+        }
+
+        const feedType = activity.feed.type;
+        if (BOTTLE_TYPES.includes(feedType as BottleFeedType)) {
+          const vol = (activity.feed as { type: BottleFeedType; volume: { ml: number } }).volume.ml;
+          total24hMl += vol;
+          bottleCount++;
+        }
+      } else if (activity.type === 'diaper_change') {
+        hasAny = true;
+        const diaperType = activity.diaperChange.type;
+        if (diaperType === 'wet') wet++;
+        else if (diaperType === 'dirty') dirty++;
+        else if (diaperType === 'mixed') mixed++;
+      }
+    }
+  }
+
+  let threeHourAvgMl = 0;
+  if (bottleCount >= 2) {
+    const bottleFeedsInWindow: { dateMs: number; volumeMl: number }[] = [];
+    for (const activity of activities) {
+      const tsMs = Date.parse(activity.timestamp);
+      if (tsMs <= nowMs && tsMs > windowStartMs && activity.type === 'feed') {
+        const feedType = activity.feed.type;
+        if (BOTTLE_TYPES.includes(feedType as BottleFeedType)) {
+          bottleFeedsInWindow.push({
+            dateMs: tsMs,
+            volumeMl: (activity.feed as { type: BottleFeedType; volume: { ml: number } }).volume.ml,
+          });
+        }
+      }
+    }
+
+    if (bottleFeedsInWindow.length >= 2) {
+      bottleFeedsInWindow.sort((a, b) => b.dateMs - a.dateMs);
+      const latest = bottleFeedsInWindow[0];
+      const earliest = bottleFeedsInWindow[bottleFeedsInWindow.length - 1];
+      const totalVol = bottleFeedsInWindow.reduce((sum, f) => sum + f.volumeMl, 0);
+      const totalDurationMins = (latest.dateMs - earliest.dateMs) / (60 * 1000);
+      if (totalDurationMins > 0) {
+        const minutelyVolume = (totalVol - latest.volumeMl) / totalDurationMins;
+        threeHourAvgMl = Math.ceil(minutelyVolume * 60 * 3);
+      }
+    }
+  }
+
+  return {
+    hasAny,
+    feed: {
+      lastFeedAtMs,
+      threeHourAvgMl,
+      total24hMl,
+      bottleCount,
+    },
+    diapers: {
+      wet,
+      dirty,
+      mixed,
+      total: wet + dirty + mixed,
+    },
+  };
+}

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
@@ -5,7 +5,7 @@ export interface Last24hSummary {
   hasAny: boolean;
   feed: {
     lastFeedAtMs: number | null;
-    threeHourAvgMl: number;
+    last3hMl: number;
     total24hMl: number;
     bottleCount: number;
   };
@@ -27,11 +27,13 @@ export function computeLast24hSummary(
 
   let lastFeedAtMs: number | null = null;
   let total24hMl = 0;
+  let last3hMl = 0;
   let bottleCount = 0;
   let wet = 0;
   let dirty = 0;
   let mixed = 0;
   let hasAny = false;
+  const threeHourBoundaryMs = nowMs - 3 * 60 * 60 * 1000;
 
   for (const activity of activities) {
     const tsMs = Date.parse(activity.timestamp);
@@ -46,6 +48,9 @@ export function computeLast24hSummary(
         if (BOTTLE_TYPES.includes(feedType as BottleFeedType)) {
           const vol = (activity.feed as { type: BottleFeedType; volume: { ml: number } }).volume.ml;
           total24hMl += vol;
+          if (tsMs > threeHourBoundaryMs) {
+            last3hMl += vol;
+          }
           bottleCount++;
         }
       } else if (activity.type === 'diaper_change') {
@@ -58,40 +63,11 @@ export function computeLast24hSummary(
     }
   }
 
-  let threeHourAvgMl = 0;
-  if (bottleCount >= 2) {
-    const bottleFeedsInWindow: { dateMs: number; volumeMl: number }[] = [];
-    for (const activity of activities) {
-      const tsMs = Date.parse(activity.timestamp);
-      if (tsMs <= nowMs && tsMs > windowStartMs && activity.type === 'feed') {
-        const feedType = activity.feed.type;
-        if (BOTTLE_TYPES.includes(feedType as BottleFeedType)) {
-          bottleFeedsInWindow.push({
-            dateMs: tsMs,
-            volumeMl: (activity.feed as { type: BottleFeedType; volume: { ml: number } }).volume.ml,
-          });
-        }
-      }
-    }
-
-    if (bottleFeedsInWindow.length >= 2) {
-      bottleFeedsInWindow.sort((a, b) => b.dateMs - a.dateMs);
-      const latest = bottleFeedsInWindow[0];
-      const earliest = bottleFeedsInWindow[bottleFeedsInWindow.length - 1];
-      const totalVol = bottleFeedsInWindow.reduce((sum, f) => sum + f.volumeMl, 0);
-      const totalDurationMins = (latest.dateMs - earliest.dateMs) / (60 * 1000);
-      if (totalDurationMins > 0) {
-        const minutelyVolume = (totalVol - latest.volumeMl) / totalDurationMins;
-        threeHourAvgMl = Math.ceil(minutelyVolume * 60 * 3);
-      }
-    }
-  }
-
   return {
     hasAny,
     feed: {
       lastFeedAtMs,
-      threeHourAvgMl,
+      last3hMl,
       total24hMl,
       bottleCount,
     },

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
@@ -2,7 +2,6 @@ import type { Activity } from '../../activity/Activity';
 import type { BottleFeedType } from '../../activity/Activity';
 
 export interface Last24hSummary {
-  hasAny: boolean;
   feed: {
     lastFeedAtMs: number | null;
     last3hMl: number;
@@ -32,14 +31,12 @@ export function computeLast24hSummary(
   let wet = 0;
   let dirty = 0;
   let mixed = 0;
-  let hasAny = false;
   const threeHourBoundaryMs = nowMs - 3 * 60 * 60 * 1000;
 
   for (const activity of activities) {
     const tsMs = Date.parse(activity.timestamp);
     if (tsMs <= nowMs && tsMs > windowStartMs) {
       if (activity.type === 'feed') {
-        hasAny = true;
         if (tsMs > (lastFeedAtMs ?? 0)) {
           lastFeedAtMs = tsMs;
         }
@@ -54,7 +51,6 @@ export function computeLast24hSummary(
           bottleCount++;
         }
       } else if (activity.type === 'diaper_change') {
-        hasAny = true;
         const diaperType = activity.diaperChange.type;
         if (diaperType === 'wet') wet++;
         else if (diaperType === 'dirty') dirty++;
@@ -64,7 +60,6 @@ export function computeLast24hSummary(
   }
 
   return {
-    hasAny,
     feed: {
       lastFeedAtMs,
       last3hMl,

--- a/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
@@ -1,0 +1,14 @@
+import { DateTime } from 'luxon';
+import type { IActivityRepository } from '../../repositories/IActivityRepository';
+import type { Last24hSummary } from './ComputeLast24hSummary';
+import { computeLast24hSummary } from './ComputeLast24hSummary';
+
+export async function getLast24hSummary(
+  repo: IActivityRepository,
+  nowMs: number
+): Promise<Last24hSummary> {
+  const fromIso = DateTime.fromMillis(nowMs - 24 * 60 * 60 * 1000).toISO()!;
+  const toIso = DateTime.fromMillis(nowMs).toISO()!;
+  const activities = await repo.listByTimestampRange('', fromIso, toIso);
+  return computeLast24hSummary(activities, nowMs);
+}

--- a/services/backend/src/domain/usecases/activity/index.ts
+++ b/services/backend/src/domain/usecases/activity/index.ts
@@ -6,3 +6,5 @@ export { updateActivity } from './UpdateActivity';
 export { deleteActivity } from './DeleteActivity';
 export { getActivityById } from './GetActivityById';
 export { getActivities } from './GetActivities';
+export { computeLast24hSummary } from './ComputeLast24hSummary';
+export { getLast24hSummary } from './GetLast24hSummary';

--- a/services/backend/src/infra/ConvexActivityRepository.ts
+++ b/services/backend/src/infra/ConvexActivityRepository.ts
@@ -81,4 +81,27 @@ export class ConvexActivityRepository implements IActivityRepository {
       continueCursor: result.continueCursor,
     };
   }
+
+  async listByTimestampRange(
+    deviceId: string,
+    fromIso: string,
+    toIso: string
+  ): Promise<Activity[]> {
+    const stream = await activityStreamForDevice(this.ctx, { deviceId });
+    if (!stream) {
+      throw new Error(`activity stream not found for device: ${deviceId}`);
+    }
+    const docs = await this.ctx.db
+      .query('activities')
+      .withIndex('by_activityStreamId_by_timestamp', (q) =>
+        q
+          .eq('activityStreamId', stream._id)
+          .gte('activity.timestamp', fromIso)
+          .lte('activity.timestamp', toIso)
+      )
+      .order('asc')
+      .collect();
+
+    return docs.map((doc) => doc.activity as Activity);
+  }
 }

--- a/services/backend/src/infra/ConvexWebActivityRepository.ts
+++ b/services/backend/src/infra/ConvexWebActivityRepository.ts
@@ -111,4 +111,27 @@ export class ConvexWebActivityRepository implements IActivityRepository {
       continueCursor: result.continueCursor,
     };
   }
+
+  /**
+   * List ALL activities in the repository's activity stream whose timestamp
+   * falls within [fromIso, toIso] (inclusive), ordered by timestamp ascending.
+   */
+  async listByTimestampRange(
+    _deviceId: string,
+    fromIso: string,
+    toIso: string
+  ): Promise<Activity[]> {
+    const docs = await this.ctx.db
+      .query('activities')
+      .withIndex('by_activityStreamId_by_timestamp', (q) =>
+        q
+          .eq('activityStreamId', this.activityStreamId)
+          .gte('activity.timestamp', fromIso)
+          .lte('activity.timestamp', toIso)
+      )
+      .order('asc')
+      .collect();
+
+    return docs.map((doc) => doc.activity);
+  }
 }


### PR DESCRIPTION
## Summary
Replaces the rose-coloured "Feeding Summary" card on the home page with a compact, indigo "Last 24h Summary" card that includes diaper info, and moves the 24h aggregation server-side.

## Changes
### Server-side query
- New `getLast24hSummary({ nowIso })` Convex query — fetches ALL activities in the 24h window (no pagination cap), aggregates server-side, returns the shape the UI needs
- New repo method `IActivityRepository.listByTimestampRange()` using the existing `by_activityStreamId_by_timestamp` index — **no schema change**
- Pure aggregation use case `computeLast24hSummary()` shared between query + tests; mirrors the old extrapolation formula exactly so numbers do not shift

### 5-min bucketed subscription
- New `useNowBucket5Min()` hook returns a UTC ISO rounded UP to the next 5-min boundary
- Single re-arming `setTimeout` (not a 1Hz interval) — re-fires exactly when the boundary crosses
- Convex memoizes per bucket → ≤12 query revalidations/hour per open tab

### Compact card
- `Last24hSummaryCard` — indigo, matches `DailySummaryCard` aesthetic, no taller than the old card
- Feed (last + 3h avg + 24h extrapolation) on the left; Diapers (`X wet · Y mixed · Z dirty`) on the right
- Extrapolated values hidden when <2 bottle feeds; card hides entirely when no activity
- Card prop type derived from Convex API via `FunctionReturnType<...>` — zero type drift

### Removals
- `computeSummaryStats`, `SummaryStats`, old rose JSX, unused imports (`Clock`, `FlaskConical`, `Calendar`, `timeAgoFromMs`) removed from `app/page.tsx`
- Old "Feeding Summary" tests replaced with `Last24hSummaryCard` tests

## Verification
- `pnpm typecheck` ✅
- `pnpm test` ✅ 221 webapp + 11 backend + 9 mobile

## Notes
`pnpm lint` has a pre-existing config error (missing `@convex-dev/eslint-plugin`) unrelated to this PR.