### PR TITLE
feat(diaper): add optional remarks field to diaper change activities

### DIFF
--- a/apps/webapp/src/app/app/diaper-change/create/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/create/page.tsx
@@ -34,6 +34,7 @@ export default function DiaperCreatePage() {
 
   const [diaperType, setDiaperType] = useState<DiaperType>('wet');
   const [datetime, setDatetime] = useState(getDefaultDatetime());
+  const [remarks, setRemarks] = useState('');
   const [saving, setSaving] = useState(false);
 
   // Unauthenticated guard — after all hooks
@@ -50,7 +51,7 @@ export default function DiaperCreatePage() {
         activity: {
           timestamp,
           type: 'diaper_change',
-          diaperChange: { type: diaperType },
+          diaperChange: { type: diaperType, remarks: remarks || undefined },
         },
       } as any);
 
@@ -112,6 +113,16 @@ export default function DiaperCreatePage() {
                 className="h-11 w-auto max-w-full"
                 value={datetime}
                 onChange={(e) => setDatetime(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="remarks">Remarks (optional)</Label>
+              <Input
+                id="remarks"
+                type="text"
+                placeholder="Add a note..."
+                value={remarks}
+                onChange={(e) => setRemarks(e.target.value)}
               />
             </div>
           </CardContent>

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
@@ -56,6 +56,7 @@ export default function DiaperEditPage() {
 
   const [diaperType, setDiaperType] = useState<DiaperType>('wet');
   const [datetime, setDatetime] = useState('');
+  const [remarks, setRemarks] = useState('');
   const [initialized, setInitialized] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -68,8 +69,10 @@ export default function DiaperEditPage() {
     const existingType = dc?.type as string;
     const ts = activity.timestamp as string;
 
+    const existingRemarks = dc?.remarks as string | undefined;
     setDiaperType((existingType as DiaperType) || 'wet');
     setDatetime(ts ? toLocalDatetimeString(ts) : '');
+    setRemarks(existingRemarks || '');
     setInitialized(true);
   }, [activity, initialized]);
 
@@ -125,7 +128,7 @@ export default function DiaperEditPage() {
         activity: {
           timestamp,
           type: 'diaper_change',
-          diaperChange: { type: diaperType },
+          diaperChange: { type: diaperType, remarks: remarks || undefined },
         },
       } as any);
 
@@ -216,6 +219,16 @@ export default function DiaperEditPage() {
                 className="h-11 w-auto max-w-full"
                 value={datetime}
                 onChange={(e) => setDatetime(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="remarks">Remarks (optional)</Label>
+              <Input
+                id="remarks"
+                type="text"
+                placeholder="Add a note..."
+                value={remarks}
+                onChange={(e) => setRemarks(e.target.value)}
               />
             </div>
           </CardContent>

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -54,7 +54,8 @@ function getActivityDisplay(activity: any): { label: string; sub: string } {
   if (type === 'diaper_change') {
     const d = activity.diaperChange;
     const typeLabel: string = (d.type as string).charAt(0).toUpperCase() + (d.type as string).slice(1);
-    return { label: 'Diaper Change', sub: typeLabel };
+    const sub = d.remarks ? `${typeLabel} · ${d.remarks}` : typeLabel;
+    return { label: 'Diaper Change', sub };
   }
 
   if (type === 'medical') {

--- a/services/backend/convex/schema.ts
+++ b/services/backend/convex/schema.ts
@@ -52,6 +52,7 @@ export default defineSchema({
             v.literal('dirty'),
             v.literal('mixed')
           ),
+          remarks: v.optional(v.string()),
         }),
       }),
       // medical activity

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -59,6 +59,7 @@ const activityValidator = v.union(
         v.literal('dirty'),
         v.literal('mixed')
       ),
+      remarks: v.optional(v.string()),
     }),
   }),
   // medical activity


### PR DESCRIPTION
## Summary
- Adds an optional free-text `remarks` field to diaper change activities
- Schema and API validator updated with `v.optional(v.string())` — fully backward-compatible with existing records
- Log Diaper and Edit Diaper forms include a "Remarks (optional)" text input
- Activity feed shows remarks inline when present (e.g. "Wet · rash noted"), falls back gracefully for older entries

## Test plan
- [ ] Log a new diaper change with a remark — verify it saves and appears in the feed
- [ ] Log a new diaper change without a remark — verify feed shows type only (e.g. "Wet")
- [ ] Edit an existing diaper entry — verify remarks field is pre-populated correctly
- [ ] Clear a remark on edit and save — verify it's removed from the feed display
- [ ] `pnpm typecheck && pnpm test` — 222 tests passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)