### PR TITLE
feat(webapp): show minutes alongside hours in time-ago display

### DIFF
--- a/apps/webapp/src/lib/activity-form-utils.ts
+++ b/apps/webapp/src/lib/activity-form-utils.ts
@@ -79,7 +79,10 @@ export function timeAgoFromMs(diffMs: number): string {
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes} min ago`;
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) {
+    const rem = minutes % 60;
+    return rem > 0 ? `${hours}h ${rem}min ago` : `${hours}h ago`;
+  }
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
 }

--- a/apps/webapp/src/modules/baby-tracker/DailySummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/DailySummaryCard.spec.tsx
@@ -139,7 +139,7 @@ describe('DailySummaryCard', () => {
         medical: null,
       };
       render(<DailySummaryCard isToday summary={summary} />);
-      expect(screen.getByText(/Last mixed: 1h ago/)).toBeInTheDocument();
+      expect(screen.getByText(/Last mixed: 1h 30min ago/)).toBeInTheDocument();
     });
   });
 

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -38,7 +38,7 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText(/90 ml/)).toBeInTheDocument();
     expect(screen.getByText(/24h:/)).toBeInTheDocument();
     expect(screen.getByText(/240 ml/)).toBeInTheDocument();
-    expect(screen.getByText(/^\d+h ago$/)).toBeInTheDocument();
+    expect(screen.getByText(/^\d+h( \d+min)? ago$/)).toBeInTheDocument();
   });
 
   it('renders non-zero values alongside em-dashes for zero values', () => {
@@ -81,7 +81,7 @@ describe('Last24hSummaryCard', () => {
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    const timeAgoEl = screen.getByText(/^\d+h ago$/);
+    const timeAgoEl = screen.getByText(/^\d+h( \d+min)? ago$/);
     expect(timeAgoEl.className).not.toMatch(/font-medium/);
     expect(timeAgoEl.className).toMatch(/text-foreground/);
     const vol3h = screen.getByText(/^60 ml$/);


### PR DESCRIPTION
## Summary
- Updates `timeAgoFromMs` in `activity-form-utils.ts` to include sub-hour minutes in the display (e.g. `1h 30min ago` instead of `1h ago`)
- Exact-hour values still render cleanly without suffix (e.g. `1h ago`, `2h ago`)
- Affects the **Last 24h Summary** card's "Last:" feed field and the **Daily Summary** card's diaper "Last wet/dirty/mixed" fields

## Test plan
- [ ] In the Last 24h Summary card, verify "Last:" shows "1h 30min ago" for a feed that was 90 minutes ago
- [ ] Verify an exact-hour feed shows "1h ago" (no extra suffix)
- [ ] `pnpm typecheck && pnpm test` — 222 tests passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)