### PR TITLE
fix(webapp): add skeleton loading state to Last24hSummaryCard to reduce CLS

### DIFF
--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -320,7 +320,7 @@ export default function AppHomePage() {
       <QuickActionGrid router={router} />
 
       {/* Last 24h summary */}
-      {last24h && <Last24hSummaryCard summary={last24h} nowMs={nowMs} />}
+      <Last24hSummaryCard summary={last24h} nowMs={nowMs} />
 
       {/* Grouped activity list */}
       {groupedByDate.map((dateGroup) => {

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -8,6 +8,13 @@ beforeEach(() => {
 });
 
 describe('Last24hSummaryCard', () => {
+  it('renders a skeleton placeholder when summary is undefined', () => {
+    render(<Last24hSummaryCard summary={undefined} nowMs={Date.now()} />);
+    expect(screen.getByText('Last 24h')).toBeInTheDocument();
+    expect(screen.queryByText(/Last:/)).not.toBeInTheDocument();
+  });
+
+
   it('renders all 6 rows even when all values are empty or zero', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Milk, Baby, Clock } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
 import { timeAgoFromMs } from '@/lib/activity-form-utils';
 import type { FunctionReturnType } from 'convex/server';
 import { api } from '@workspace/backend/convex/_generated/api';
@@ -10,11 +11,38 @@ const DASH = '\u2014';
 type Last24hSummary = FunctionReturnType<typeof api.web.babyTracker.activities.getLast24hSummary>;
 
 interface Last24hSummaryCardProps {
-  summary: Last24hSummary;
+  summary: Last24hSummary | undefined;
   nowMs: number;
 }
 
 export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) {
+  if (!summary) {
+    return (
+      <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
+        <div className="flex items-center gap-1.5 px-4 pt-2 pb-1">
+          <Clock className="h-3.5 w-3.5 text-rose-600 dark:text-rose-400" />
+          <span className="text-xs font-semibold text-rose-900 dark:text-rose-200 uppercase tracking-wide">
+            Last 24h
+          </span>
+        </div>
+        <div className="grid grid-cols-2 gap-3 px-4 pb-2">
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const { feed, diapers } = summary;
 
   return (


### PR DESCRIPTION
## Summary
- `Last24hSummaryCard` now accepts `summary: Last24hSummary | undefined` and renders a skeleton placeholder when data is loading
- The skeleton uses the same outer wrapper (border, background, rounded-lg) and header as the real card, so the layout space is always reserved
- Removed the `{last24h && ...}` conditional guard in `page.tsx` — the card always renders, eliminating the pop-in CLS
- Added a test verifying the skeleton state (header visible, data rows absent)

## Test plan
- [ ] On a slow connection (or with throttling in DevTools), verify the Last 24h card appears immediately as a skeleton, then smoothly fills in with data — no layout shift
- [ ] Verify the loaded card still looks and behaves correctly
- [ ] `pnpm typecheck && pnpm test` — 223 tests passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)