### PR TITLE
refactor(webapp): replace count-based pagination with day-range subscription

### DIFF
--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -2,17 +2,17 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { Loader2, Milk, Baby, Stethoscope, Sunrise, Sun, Moon, Stars } from 'lucide-react';
 import { DateTime } from 'luxon';
-import { useSessionPaginatedQuery, useSessionQuery } from 'convex-helpers/react/sessions';
+import { useSessionQuery } from 'convex-helpers/react/sessions';
 import { api } from '@workspace/backend/convex/_generated/api';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthState } from '@/modules/auth/AuthProvider';
-import { computeDailySummariesByDay, DailySummary } from '@/lib/daily-summary';
+import { computeDailySummariesByDay, computeLast24hSummary, DailySummary } from '@/lib/daily-summary';
 import { DailySummaryCard } from '@/modules/baby-tracker/DailySummaryCard';
 import { Last24hSummaryCard } from '@/modules/baby-tracker/Last24hSummaryCard';
 import { useNowBucket5Min } from '@/lib/use-now-bucket';
@@ -174,20 +174,27 @@ export default function AppHomePage() {
   const authState = useAuthState();
   const isAuthenticated = authState?.state === 'authenticated';
 
-  const paginated = useSessionPaginatedQuery(
-    api.web.babyTracker.activities.getByTimestampDescPaginated,
-    {},
-    { initialNumItems: 20 }
-  );
-
-  const results = paginated?.results ?? [];
-  const status = paginated?.status ?? 'LoadingFirstPage';
-  const isLoading = paginated?.isLoading ?? true;
-  const loadMore = paginated?.loadMore;
+  const [daysBack, setDaysBack] = useState(2);
 
   const nowIso = useNowBucket5Min();
   const nowMs = DateTime.fromISO(nowIso).toMillis();
-  const last24h = useSessionQuery(api.web.babyTracker.activities.getLast24hSummary, { nowIso });
+
+  const fromIso = useMemo(
+    () => DateTime.now().startOf('day').minus({ days: daysBack - 1 }).toISO()!,
+    [daysBack]
+  );
+
+  const rangeResult = useSessionQuery(
+    api.web.babyTracker.activities.getActivitiesByDateRange,
+    { fromIso, toIso: nowIso }
+  );
+  const results = rangeResult ?? [];
+  const isLoading = rangeResult === undefined;
+
+  const last24h = useMemo(
+    () => (rangeResult !== undefined ? computeLast24hSummary(results, nowMs) : undefined),
+    [results, nowMs, rangeResult]
+  );
 
   // ── Per-day summary computation ──────────────────────────────
   const dailySummariesByDay = useMemo(() => computeDailySummariesByDay(results), [results]);
@@ -396,16 +403,16 @@ export default function AppHomePage() {
       })}
 
       {/* Load more */}
-      {status === 'CanLoadMore' && (
+      {!isLoading && (
         <div className="flex justify-center mt-4">
-          <Button variant="outline" onClick={() => loadMore?.(20)}>
+          <Button variant="outline" onClick={() => setDaysBack((d) => d + 1)}>
             Load More
           </Button>
         </div>
       )}
 
       {/* Loading more indicator */}
-      {status === 'LoadingMore' && (
+      {isLoading && results.length > 0 && (
         <div className="flex justify-center mt-4">
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -184,10 +184,14 @@ export default function AppHomePage() {
   const nowIso = useNowBucket5Min();
   const nowMs = DateTime.fromISO(nowIso).toMillis();
 
-  const fromIso = useMemo(
-    () => DateTime.now().startOf('day').minus({ days: daysBack - 1 }).toISO()!,
-    [daysBack]
-  );
+  const fromIso = useMemo(() => {
+    // Load from the requested number of days back, but always at least from yesterday midnight.
+    // The last-24h summary needs activities from (now - 24h), which always falls on yesterday,
+    // so we must never load less than yesterday's data regardless of daysBack.
+    const requestedFrom = DateTime.now().startOf('day').minus({ days: daysBack - 1 });
+    const minFrom = DateTime.now().startOf('day').minus({ days: 1 }); // yesterday midnight
+    return (requestedFrom < minFrom ? requestedFrom : minFrom).toISO()!;
+  }, [daysBack]);
 
   const rangeResult = useSessionQuery(
     api.web.babyTracker.activities.getActivitiesByDateRange,

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -7,6 +7,7 @@ import { Loader2, Milk, Baby, Stethoscope, Sunrise, Sun, Moon, Stars } from 'luc
 import { DateTime } from 'luxon';
 import { useSessionQuery } from 'convex-helpers/react/sessions';
 import { api } from '@workspace/backend/convex/_generated/api';
+import type { FunctionReturnType } from 'convex/server';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -23,13 +24,18 @@ import {
   formatDuration,
 } from '@/lib/activity-form-utils';
 
+// ── Types ────────────────────────────────────────────────────────
+
+/** Activity item as returned by the date-range query (includes Convex _id). */
+type ActivityItem = NonNullable<
+  FunctionReturnType<typeof api.web.babyTracker.activities.getActivitiesByDateRange>
+>[number];
+
 // ── Helpers ─────────────────────────────────────────────────────
 
 /** Get a human-readable label and sub-detail for an activity. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getActivityDisplay(activity: any): { label: string; sub: string } {
-  const type: string = activity.type;
-  if (type === 'feed') {
+function getActivityDisplay(activity: ActivityItem): { label: string; sub: string } {
+  if (activity.type === 'feed') {
     const feed = activity.feed;
     switch (feed.type) {
       case 'latch': {
@@ -47,18 +53,18 @@ function getActivityDisplay(activity: any): { label: string; sub: string } {
       case 'water':
         return { label: 'Water Feed', sub: `${feed.volume.ml} ml` };
       case 'solids':
-        return { label: 'Solids Feed', sub: feed.description as string };
+        return { label: 'Solids Feed', sub: feed.description };
     }
   }
 
-  if (type === 'diaper_change') {
+  if (activity.type === 'diaper_change') {
     const d = activity.diaperChange;
-    const typeLabel: string = (d.type as string).charAt(0).toUpperCase() + (d.type as string).slice(1);
+    const typeLabel = d.type.charAt(0).toUpperCase() + d.type.slice(1);
     const sub = d.remarks ? `${typeLabel} · ${d.remarks}` : typeLabel;
     return { label: 'Diaper Change', sub };
   }
 
-  if (type === 'medical') {
+  if (activity.type === 'medical') {
     const med = activity.medical;
     switch (med.type) {
       case 'temperature':
@@ -75,8 +81,7 @@ function getActivityDisplay(activity: any): { label: string; sub: string } {
 }
 
 /** Build the edit navigation path for an activity (new routes). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getEditPath(activity: any): string {
+function getEditPath(activity: ActivityItem): string {
   switch (activity.type) {
     case 'feed':
       return `/app/feed/edit/${activity._id}`;
@@ -209,17 +214,16 @@ export default function AppHomePage() {
   // Precompute today's dateKey — recomputes when results refresh (acceptable; midnight rollover is rare)
   const todayKey = useMemo(() => toDateKey(DateTime.now()), [results]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const groupedByDate = useMemo(() => {
-    const sorted = [...(results as any[])].sort((a, b) => {
-      const tsA = DateTime.fromISO(a.timestamp as string).toMillis();
-      const tsB = DateTime.fromISO(b.timestamp as string).toMillis();
+    const sorted = [...results].sort((a, b) => {
+      const tsA = DateTime.fromISO(a.timestamp).toMillis();
+      const tsB = DateTime.fromISO(b.timestamp).toMillis();
       return tsB - tsA;
     });
 
     const dateGroups: {
       date: string;
-      timeGroups: { period: TimeOfDay; activities: any[] }[];
+      timeGroups: { period: TimeOfDay; activities: ActivityItem[] }[];
     }[] = [];
 
     for (const activity of sorted) {
@@ -335,7 +339,7 @@ export default function AppHomePage() {
         const dateKey = dateGroup.date;
         const summary = summaryByDateKey.get(dateKey);
         const isToday = dateKey === todayKey;
-        const firstTs = dateGroup.timeGroups[0].activities[0].timestamp as string;
+        const firstTs = dateGroup.timeGroups[0].activities[0].timestamp;
 
         return (
           <div key={dateKey} className="mb-6">
@@ -363,15 +367,15 @@ export default function AppHomePage() {
                     </div>
 
                     {/* Activities in this time period */}
-                    {timeGroup.activities.map((activity: any, idx: number) => {
+                    {timeGroup.activities.map((activity, idx) => {
                       const { label: actLabel, sub } = getActivityDisplay(activity);
-                      const IconComponent = ACTIVITY_ICON_MAP[activity.type as string];
+                      const IconComponent = ACTIVITY_ICON_MAP[activity.type];
                       const isLastInGroup = idx === timeGroup.activities.length - 1;
                       const isLastOverall = isLastTimeGroup && isLastInGroup;
 
                       return (
                         <Link
-                          key={activity._id as string}
+                          key={activity._id}
                           href={getEditPath(activity)}
                           prefetch={true}
                           className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-accent/50 transition-colors ${!isLastOverall ? 'border-b border-border' : ''}`}
@@ -388,7 +392,7 @@ export default function AppHomePage() {
                             <p className="text-xs text-muted-foreground truncate">{sub}</p>
                           </div>
                           <span className="text-xs text-muted-foreground flex-shrink-0">
-                            {formatTime(activity.timestamp as string)}
+                            {formatTime(activity.timestamp)}
                           </span>
                         </Link>
                       );

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -983,4 +983,51 @@ describe('App home page', () => {
       // Medical section removed — no temperature-related assertions needed
     });
   });
+
+  // ── 11. Regression: edit link IDs must not be "undefined" ────────
+  //
+  // Regression for: getActivitiesByDateRange previously returned activities
+  // without _id (used repo.listByTimestampRange which stripped doc._id).
+  // This caused all edit links on the home page to be "/app/<type>/edit/undefined".
+
+  describe('regression: activity edit link IDs must not be "undefined"', () => {
+    it('feed activity link href contains the real _id, not "undefined"', async () => {
+      mockRangeResults = [makeLatchActivity({ _id: 'convex-feed-id-abc123' })];
+
+      render(<AppHomePage />);
+
+      await waitFor(() => {
+        const link = screen.getByText('Latch Feed').closest('a');
+        expect(link).toBeTruthy();
+        expect(link?.getAttribute('href')).not.toContain('undefined');
+        expect(link?.getAttribute('href')).toBe('/app/feed/edit/convex-feed-id-abc123');
+      });
+    });
+
+    it('diaper activity link href contains the real _id, not "undefined"', async () => {
+      mockRangeResults = [makeDiaperActivity({ _id: 'convex-diaper-id-def456' })];
+
+      render(<AppHomePage />);
+
+      await waitFor(() => {
+        const link = screen.getByText('Diaper Change').closest('a');
+        expect(link).toBeTruthy();
+        expect(link?.getAttribute('href')).not.toContain('undefined');
+        expect(link?.getAttribute('href')).toBe('/app/diaper-change/edit/convex-diaper-id-def456');
+      });
+    });
+
+    it('medical activity link href contains the real _id, not "undefined"', async () => {
+      mockRangeResults = [makeTemperatureActivity({ _id: 'convex-medical-id-ghi789' })];
+
+      render(<AppHomePage />);
+
+      await waitFor(() => {
+        const link = screen.getByText('Temperature').closest('a');
+        expect(link).toBeTruthy();
+        expect(link?.getAttribute('href')).not.toContain('undefined');
+        expect(link?.getAttribute('href')).toBe('/app/medical/edit/convex-medical-id-ghi789');
+      });
+    });
+  });
 });

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -1030,4 +1030,86 @@ describe('App home page', () => {
       });
     });
   });
+
+  // ── 12. Regression: last-24h summary requires yesterday's data ────
+  //
+  // Regression for: fromIso was not clamped, so if daysBack=1 the query would
+  // start at today midnight — missing any activity from yesterday that still
+  // falls within the last-24h window (e.g., something logged at 10pm yesterday
+  // when it's currently 9am today is only 11h ago, but before today midnight).
+  //
+  // The fix: fromIso is clamped to at most yesterday midnight so the full
+  // last-24h window is always covered regardless of daysBack.
+
+  describe('regression: last-24h summary includes activities from yesterday within the 24h window', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      // Fix system time to noon on May 20 so relative timestamps are predictable.
+      vi.setSystemTime(new Date('2025-05-20T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('bottle feed from 20h ago (yesterday 16:00 UTC) IS counted in last-24h total', () => {
+      // 20h ago = May 19 16:00 UTC — within last 24h window (window starts May 19 12:00 UTC)
+      mockRangeResults = [
+        {
+          _id: 'feed-20h-ago',
+          _creationTime: Date.now() - 20 * 3600 * 1000,
+          timestamp: new Date(Date.now() - 20 * 3600 * 1000).toISOString(),
+          type: 'feed',
+          feed: { type: 'expressed', volume: { ml: 150 } },
+        },
+      ];
+
+      render(<AppHomePage />);
+
+      // Activity is within last 24h → should appear in the Last24hSummaryCard totals
+      expect(screen.getByText(/150ml/)).toBeInTheDocument();
+    });
+
+    it('bottle feed from 25h ago (yesterday 11:00 UTC) is NOT counted in last-24h total', () => {
+      // 25h ago = May 19 11:00 UTC — outside last 24h window (window starts May 19 12:00 UTC)
+      mockRangeResults = [
+        {
+          _id: 'feed-25h-ago',
+          _creationTime: Date.now() - 25 * 3600 * 1000,
+          timestamp: new Date(Date.now() - 25 * 3600 * 1000).toISOString(),
+          type: 'feed',
+          feed: { type: 'expressed', volume: { ml: 200 } },
+        },
+      ];
+
+      render(<AppHomePage />);
+
+      // Activity is outside last 24h → 24h ml total should be 0ml, not 200ml
+      // The Last 24h card is still rendered (shows skeleton/empty) — check total is absent
+      const last24hCard = screen.getByText('Last 24h').closest('div')!;
+      expect(within(last24hCard).queryByText(/200ml/)).not.toBeInTheDocument();
+    });
+
+    it('wet diaper from 23h ago (yesterday 13:00 UTC) IS counted in last-24h diaper total', () => {
+      // 23h ago = May 19 13:00 UTC — within last 24h window
+      mockRangeResults = [
+        {
+          _id: 'diaper-23h-ago',
+          _creationTime: Date.now() - 23 * 3600 * 1000,
+          timestamp: new Date(Date.now() - 23 * 3600 * 1000).toISOString(),
+          type: 'diaper_change',
+          diaperChange: { type: 'wet' },
+        },
+      ];
+
+      render(<AppHomePage />);
+
+      // Last24hSummaryCard renders diapers as separate label + count elements: "Wet:" / "1"
+      // Find the Last 24h section and assert Wet count is "1" (not "—")
+      const last24hSection = screen.getByText('Last 24h').closest('div')!.parentElement!;
+      expect(within(last24hSection).getByText('Wet:')).toBeInTheDocument();
+      const wetLabel = within(last24hSection).getByText('Wet:');
+      expect(wetLabel.nextElementSibling?.textContent).toBe('1');
+    });
+  });
 });

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -40,24 +40,14 @@ vi.mock('next/link', () => createNextLinkMock());
 vi.mock('convex/react', () => createConvexReactMock());
 vi.mock('@workspace/backend/convex/_generated/api', () => createApiMock());
 
-// ── Mutable paginated query state ───────────────────────────────
+// ── Mutable query state ─────────────────────────────────────────
 
-let mockResults: Record<string, unknown>[] = [];
-let mockStatus: string = 'Exhausted';
-let mockIsLoading = false;
-const mockLoadMore = vi.fn();
-
-let mockLast24h: Record<string, unknown> | null = null;
+let mockRangeResults: Record<string, unknown>[] | undefined = [];
 
 vi.mock('convex-helpers/react/sessions', () => ({
   SessionProvider: ({ children }: { children: ReactNode }) => children,
-  useSessionPaginatedQuery: () => ({
-    results: mockResults,
-    status: mockStatus,
-    isLoading: mockIsLoading,
-    loadMore: mockLoadMore,
-  }),
-  useSessionQuery: (_api: unknown, _args: unknown) => mockLast24h,
+  useSessionPaginatedQuery: () => undefined,
+  useSessionQuery: (_api: unknown, _args: unknown) => mockRangeResults,
 }));
 
 // ── Mutable auth state ──────────────────────────────────────────
@@ -79,12 +69,8 @@ vi.mock('@/modules/auth/AuthProvider', () => ({
 
 /** Reset all mutable mock state between tests. */
 function resetMocks() {
-  mockResults = [];
-  mockStatus = 'Exhausted';
-  mockIsLoading = false;
-  mockLast24h = null;
+  mockRangeResults = [];
   mockRouterPush.mockClear();
-  mockLoadMore.mockClear();
   currentAuthState = {
     sessionId: 'test-session',
     state: 'authenticated',
@@ -198,9 +184,7 @@ describe('App home page', () => {
 
   describe('loading state', () => {
     it('shows skeletons while fetching activities', () => {
-      mockIsLoading = true;
-      mockStatus = 'LoadingFirstPage';
-      mockResults = [];
+      mockRangeResults = undefined;
 
       render(<AppHomePage />);
 
@@ -214,9 +198,9 @@ describe('App home page', () => {
 
   describe('empty state', () => {
     it('shows empty message when no activities exist', async () => {
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-      mockResults = [];
+
+
+      mockRangeResults = [];
 
       render(<AppHomePage />);
 
@@ -226,9 +210,9 @@ describe('App home page', () => {
     });
 
     it('shows action buttons even when empty', async () => {
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-      mockResults = [];
+
+
+      mockRangeResults = [];
 
       render(<AppHomePage />);
 
@@ -243,15 +227,10 @@ describe('App home page', () => {
   // ── 3. Last 24h summary card ────────────────────────────────────
 
   describe('last 24h summary card', () => {
-    const last24hFixture = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
-      diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
-    };
-
     it('shows Last24hSummaryCard when query returns data', () => {
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-      mockResults = [
+
+
+      mockRangeResults = [
         {
           _id: 'b1',
           _creationTime: Date.now() - 1000,
@@ -260,7 +239,6 @@ describe('App home page', () => {
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
       ];
-      mockLast24h = last24hFixture;
 
       const { container } = render(<AppHomePage />);
       expect(container.textContent).toContain('Last 24h');
@@ -271,10 +249,10 @@ describe('App home page', () => {
 
   describe('activity display', () => {
     beforeEach(() => {
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
       // No fake timers — activity display tests don't need DateTime.now()
-      mockResults = [
+      mockRangeResults = [
         makeLatchActivity(),
         makeBottleActivity(),
         makeSolidsActivity(),
@@ -329,15 +307,15 @@ describe('App home page', () => {
 
   describe('date grouping', () => {
     it('groups activities by date with separators', async () => {
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
       // Timestamps chosen to span two local dates in UTC+8 (Asia/Singapore).
       // Midnight SGT = 16:00 Z.
       // Jan 14 23:59 Z → SGT Jan 14 (night) — local date = Jan 14.
       // Jan 15 00:00 Z → SGT Jan 15 (midnight) — local date = Jan 15.
       // Jan 15 08:00 Z → SGT Jan 15 16:00 (afternoon) — local date = Jan 15.
       // Jan 15 12:00 Z → SGT Jan 15 20:00 (night) — local date = Jan 15.
-      mockResults = [
+      mockRangeResults = [
         makeLatchActivity({ timestamp: '2025-01-14T15:59:59.000Z' }),
         makeSolidsActivity({ timestamp: '2025-01-14T16:00:00.000Z' }),
         makeBottleActivity({ timestamp: '2025-01-15T08:00:00.000Z' }),
@@ -357,9 +335,9 @@ describe('App home page', () => {
 
   describe('action buttons', () => {
     it('shows Log Feed, Log Diaper, Log Medical buttons when authenticated', async () => {
-      mockResults = [];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [];
+
+
 
       render(<AppHomePage />);
 
@@ -371,9 +349,9 @@ describe('App home page', () => {
     });
 
     it('Log Feed navigates to /app/feed/create', async () => {
-      mockResults = [];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [];
+
+
 
       render(<AppHomePage />);
 
@@ -387,9 +365,9 @@ describe('App home page', () => {
     });
 
     it('Log Diaper navigates to /app/diaper-change/create', async () => {
-      mockResults = [];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [];
+
+
 
       render(<AppHomePage />);
 
@@ -403,9 +381,9 @@ describe('App home page', () => {
     });
 
     it('Log Medical navigates to /app/medical/create', async () => {
-      mockResults = [];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [];
+
+
 
       render(<AppHomePage />);
 
@@ -423,9 +401,9 @@ describe('App home page', () => {
 
   describe('row click navigation', () => {
     it('links to feed edit page at /app/feed/edit/[id]', async () => {
-      mockResults = [makeLatchActivity({ _id: 'act-feed-1' })];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [makeLatchActivity({ _id: 'act-feed-1' })];
+
+
 
       render(<AppHomePage />);
 
@@ -438,9 +416,9 @@ describe('App home page', () => {
     });
 
     it('links to diaper edit page at /app/diaper-change/edit/[id]', async () => {
-      mockResults = [makeDiaperActivity({ _id: 'act-diaper-1' })];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [makeDiaperActivity({ _id: 'act-diaper-1' })];
+
+
 
       render(<AppHomePage />);
 
@@ -453,9 +431,9 @@ describe('App home page', () => {
     });
 
     it('links to medical edit page at /app/medical/edit/[id]', async () => {
-      mockResults = [makeTemperatureActivity({ _id: 'act-med-1' })];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [makeTemperatureActivity({ _id: 'act-med-1' })];
+
+
 
       render(<AppHomePage />);
 
@@ -472,9 +450,9 @@ describe('App home page', () => {
 
   describe('load more', () => {
     it('shows load more button when more pages available', async () => {
-      mockResults = [makeLatchActivity()];
-      mockIsLoading = false;
-      mockStatus = 'CanLoadMore';
+      mockRangeResults = [makeLatchActivity()];
+
+
 
       render(<AppHomePage />);
 
@@ -483,10 +461,8 @@ describe('App home page', () => {
       });
     });
 
-    it('calls loadMore when load more button clicked', async () => {
-      mockResults = [makeLatchActivity()];
-      mockIsLoading = false;
-      mockStatus = 'CanLoadMore';
+    it('shows load more button and clicks without error', async () => {
+      mockRangeResults = [makeLatchActivity()];
 
       render(<AppHomePage />);
 
@@ -495,8 +471,6 @@ describe('App home page', () => {
       });
 
       screen.getByText(/load more/i).click();
-
-      expect(mockLoadMore).toHaveBeenCalled();
     });
   });
 
@@ -509,9 +483,9 @@ describe('App home page', () => {
         state: 'unauthenticated',
         reason: 'test',
       };
-      mockResults = [];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [];
+
+
 
       render(<AppHomePage />);
 
@@ -534,9 +508,9 @@ describe('App home page', () => {
     });
 
     it('is hidden when no activities exist', () => {
-      mockResults = [];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+      mockRangeResults = [];
+
+
 
       render(<AppHomePage />);
 
@@ -545,7 +519,7 @@ describe('App home page', () => {
 
     it('shows a yesterday card (no "Today ·" on card) when only yesterday data exists', () => {
       // yesterday 10:00 AM UTC = 2025-05-18T10:00:00Z
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'act-yesterday',
           _creationTime: Date.now() - 86400000,
@@ -554,8 +528,8 @@ describe('App home page', () => {
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -570,7 +544,7 @@ describe('App home page', () => {
 
     it('shows date heading when today has any activity', () => {
       // today at 08:00
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'act-today',
           _creationTime: Date.now(),
@@ -579,8 +553,8 @@ describe('App home page', () => {
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -591,7 +565,7 @@ describe('App home page', () => {
     it('bottle line shows breakdown with both subtypes for mixed expressed+formula', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'b1',
           _creationTime: now - 1000,
@@ -614,8 +588,8 @@ describe('App home page', () => {
           feed: { type: 'formula', volume: { ml: 120 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -629,7 +603,7 @@ describe('App home page', () => {
     it('bottle line hides breakdown parenthetical when only one active subtype', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'b1',
           _creationTime: now - 1000,
@@ -645,8 +619,8 @@ describe('App home page', () => {
           feed: { type: 'expressed', volume: { ml: 90 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -658,7 +632,7 @@ describe('App home page', () => {
     it('latch line shows session count and avg L/R via formatDuration', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'l1',
           _creationTime: now - 1000,
@@ -674,8 +648,8 @@ describe('App home page', () => {
           feed: { type: 'latch', duration: { left: { seconds: 900 }, right: { seconds: 450 } } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -687,7 +661,7 @@ describe('App home page', () => {
     it('solids deduplicates by case-insensitive name and shows all unique names', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 's1',
           _creationTime: now - 1000,
@@ -710,8 +684,8 @@ describe('App home page', () => {
           feed: { type: 'solids', description: 'Rice' },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -723,7 +697,7 @@ describe('App home page', () => {
     it('diaper counts omit zero types (2 wet + 1 mixed, 0 dirty → no dirty text)', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'd1',
           _creationTime: now - 1000,
@@ -746,22 +720,24 @@ describe('App home page', () => {
           diaperChange: { type: 'mixed' },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
-      expect(screen.getByText(/Diapers/)).toBeInTheDocument();
-      expect(screen.getByText(/2 wet/)).toBeInTheDocument();
-      expect(screen.getByText(/1 mixed/)).toBeInTheDocument();
+      // Both Last24hSummaryCard and DailySummaryCard show "Diapers" — scope to the daily card wrapper
+      const dailyCard = screen.getByText('Daily Summary').closest('div')!.parentElement!;
+      expect(within(dailyCard).getByText(/Diapers/)).toBeInTheDocument();
+      expect(within(dailyCard).getByText(/2 wet/)).toBeInTheDocument();
+      expect(within(dailyCard).getByText(/1 mixed/)).toBeInTheDocument();
       // dirty not shown
-      expect(screen.queryByText(/dirty/)).not.toBeInTheDocument();
+      expect(within(dailyCard).queryByText(/dirty/)).not.toBeInTheDocument();
     });
 
     it('diaper shows "Last wet: 2h ago" when last wet was 2 hours ago', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'd1',
           _creationTime: now - 1000,
@@ -770,8 +746,8 @@ describe('App home page', () => {
           diaperChange: { type: 'wet' },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -782,7 +758,7 @@ describe('App home page', () => {
     it('medical shows latest temperature from two readings (latest is 37.8°C)', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'm1',
           _creationTime: now - 1000,
@@ -798,8 +774,8 @@ describe('App home page', () => {
           medical: { type: 'temperature', temperature: { value: 37.0 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -812,7 +788,7 @@ describe('App home page', () => {
     it('medicine roll-up: Paracetamol 5ml + 5ml → 10ml over 2 doses', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'med1',
           _creationTime: now - 1000,
@@ -828,8 +804,8 @@ describe('App home page', () => {
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'ml', value: 5 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -841,7 +817,7 @@ describe('App home page', () => {
     it('mixed units medicine: Paracetamol 5ml + 0.5g → no total, shows "mixed units" and dose count', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'med1',
           _creationTime: now - 1000,
@@ -857,8 +833,8 @@ describe('App home page', () => {
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'g', value: 0.5 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -870,7 +846,7 @@ describe('App home page', () => {
     it('section showing: only feed today → Diapers and Medical show "No records" in the card', () => {
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'b1',
           _creationTime: now - 1000,
@@ -879,8 +855,8 @@ describe('App home page', () => {
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -899,9 +875,9 @@ describe('App home page', () => {
 
     it('DOM ordering: Last24hSummaryCard appears between quick actions and day group', () => {
       // The Last24hSummaryCard sits between QuickActionGrid and the day-group cards
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
-      mockResults = [
+
+
+      mockRangeResults = [
         {
           _id: 'b1',
           _creationTime: Date.now() - 1000,
@@ -910,10 +886,6 @@ describe('App home page', () => {
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
       ];
-      mockLast24h = {
-        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
-        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
-      };
 
       render(<AppHomePage />);
 
@@ -927,7 +899,7 @@ describe('App home page', () => {
       // Today has a bottle feed; yesterday has a wet diaper
       const now = Date.now();
       const hour = 3600 * 1000;
-      mockResults = [
+      mockRangeResults = [
         // yesterday's wet diaper
         {
           _id: 'd-yesterday',
@@ -945,8 +917,8 @@ describe('App home page', () => {
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -966,7 +938,7 @@ describe('App home page', () => {
     it('isToday=false suppresses "ago" for diaper: yesterday wet shows "Last wet at HH:mm"', () => {
       // System time = 2025-05-19T10:00:00Z → today is May 19.
       // Yesterday at 14:00 UTC
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 'd-yesterday',
           _creationTime: Date.now() - 20 * 3600 * 1000,
@@ -975,8 +947,8 @@ describe('App home page', () => {
           diaperChange: { type: 'wet' },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 
@@ -992,7 +964,7 @@ describe('App home page', () => {
     });
 
     it('isToday=false suppresses "ago" for medical temperature: yesterday shows "· at HH:mm"', () => {
-      mockResults = [
+      mockRangeResults = [
         {
           _id: 't-yesterday',
           _creationTime: Date.now() - 20 * 3600 * 1000,
@@ -1001,8 +973,8 @@ describe('App home page', () => {
           medical: { type: 'temperature', temperature: { value: 37.5 } },
         },
       ];
-      mockIsLoading = false;
-      mockStatus = 'Exhausted';
+
+
 
       render(<AppHomePage />);
 

--- a/apps/webapp/src/lib/daily-summary.spec.ts
+++ b/apps/webapp/src/lib/daily-summary.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DateTime } from 'luxon';
-import { computeDailySummary, computeDailySummariesByDay } from './daily-summary';
+import { computeDailySummary, computeDailySummariesByDay, computeLast24hSummary, type Activity } from './daily-summary';
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -416,5 +416,43 @@ describe('computeDailySummariesByDay', () => {
     expect(result).toHaveLength(1);
     expect(result[0].summary.hasAny).toBe(true);
     expect(result[0].summary.medical?.latestTemperature?.at).toBe('2025-01-15T10:00:00.000Z');
+  });
+});
+
+describe('computeLast24hSummary', () => {
+  it('returns zeros when no activities in window', () => {
+    const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+    const result = computeLast24hSummary([], nowMs);
+    expect(result.feed.lastFeedAtMs).toBeNull();
+    expect(result.feed.last3hMl).toBe(0);
+    expect(result.feed.total24hMl).toBe(0);
+    expect(result.feed.bottleCount).toBe(0);
+    expect(result.diapers).toEqual({ wet: 0, dirty: 0, mixed: 0, total: 0 });
+  });
+
+  it('counts bottle feeds correctly within the 24h window', () => {
+    const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+    const activities = [
+      makeFeed('2025-01-14T13:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
+      makeFeed('2025-01-15T08:00:00.000Z', 'formula', { volume: { ml: 90 } }),
+      makeFeed('2025-01-15T11:30:00.000Z', 'water', { volume: { ml: 30 } }),
+    ] as Activity[];
+    const result = computeLast24hSummary(activities, nowMs);
+    expect(result.feed.bottleCount).toBe(3);
+    expect(result.feed.total24hMl).toBe(180);
+    expect(result.feed.last3hMl).toBe(30);
+  });
+
+  it('excludes activities older than 24h', () => {
+    const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+    const activities = [
+      makeFeed('2025-01-13T12:00:00.000Z', 'expressed', { volume: { ml: 60 } }),
+      makeDiaper('2025-01-13T12:00:00.000Z', 'wet'),
+      makeFeed('2025-01-15T10:00:00.000Z', 'expressed', { volume: { ml: 120 } }),
+    ] as Activity[];
+    const result = computeLast24hSummary(activities, nowMs);
+    expect(result.feed.bottleCount).toBe(1);
+    expect(result.feed.total24hMl).toBe(120);
+    expect(result.diapers).toEqual({ wet: 0, dirty: 0, mixed: 0, total: 0 });
   });
 });

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -42,7 +42,7 @@ interface MedicalActivity {
   };
 }
 
-type Activity = FeedActivity | DiaperActivity | MedicalActivity;
+export type Activity = FeedActivity | DiaperActivity | MedicalActivity;
 
 // ── Date-key helper (shared with callers) ─────────────────────────────────────
 
@@ -345,4 +345,68 @@ export function computeDailySummariesByDay(
   }
 
   return entries;
+}
+
+// ── Last 24h Summary ────────────────────────────────────────────
+
+export interface Last24hSummary {
+  feed: {
+    lastFeedAtMs: number | null;
+    last3hMl: number;
+    total24hMl: number;
+    bottleCount: number;
+  };
+  diapers: {
+    wet: number;
+    dirty: number;
+    mixed: number;
+    total: number;
+  };
+}
+
+const BOTTLE_FEED_TYPES = ['expressed', 'formula', 'water'] as const;
+type BottleFeedSubType = (typeof BOTTLE_FEED_TYPES)[number];
+
+/**
+ * Compute the last-24h summary from a flat activities array.
+ * The array must cover at least the 24h window ending at nowMs.
+ */
+export function computeLast24hSummary(
+  activities: ReadonlyArray<Activity>,
+  nowMs: number
+): Last24hSummary {
+  const windowStartMs = nowMs - 24 * 60 * 60 * 1000;
+  const threeHourBoundaryMs = nowMs - 3 * 60 * 60 * 1000;
+
+  let lastFeedAtMs: number | null = null;
+  let total24hMl = 0;
+  let last3hMl = 0;
+  let bottleCount = 0;
+  let wet = 0, dirty = 0, mixed = 0;
+
+  for (const activity of activities) {
+    const tsMs = Date.parse(activity.timestamp);
+    if (tsMs <= nowMs && tsMs > windowStartMs) {
+      if (activity.type === 'feed') {
+        if (tsMs > (lastFeedAtMs ?? 0)) lastFeedAtMs = tsMs;
+        const feedType = activity.feed.type;
+        if ((BOTTLE_FEED_TYPES as readonly string[]).includes(feedType)) {
+          const vol = (activity.feed as { type: BottleFeedSubType; volume?: { ml?: number } }).volume?.ml ?? 0;
+          total24hMl += vol;
+          if (tsMs > threeHourBoundaryMs) last3hMl += vol;
+          bottleCount++;
+        }
+      } else if (activity.type === 'diaper_change') {
+        const dType = activity.diaperChange.type;
+        if (dType === 'wet') wet++;
+        else if (dType === 'dirty') dirty++;
+        else if (dType === 'mixed') mixed++;
+      }
+    }
+  }
+
+  return {
+    feed: { lastFeedAtMs, last3hMl, total24hMl, bottleCount },
+    diapers: { wet, dirty, mixed, total: wet + dirty + mixed },
+  };
 }

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -3,12 +3,9 @@
 import { Milk, Baby, Clock } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { timeAgoFromMs } from '@/lib/activity-form-utils';
-import type { FunctionReturnType } from 'convex/server';
-import { api } from '@workspace/backend/convex/_generated/api';
+import type { Last24hSummary } from '@/lib/daily-summary';
 
 const DASH = '\u2014';
-
-type Last24hSummary = FunctionReturnType<typeof api.web.babyTracker.activities.getLast24hSummary>;
 
 interface Last24hSummaryCardProps {
   summary: Last24hSummary | undefined;

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -201,9 +201,17 @@ export const getActivitiesByDateRange = query({
     toIso: v.string(),
   },
   handler: async (ctx, args) => {
-    const { userId, activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
-    const repo = new ConvexWebActivityRepository(ctx, activityStreamId);
-    const activities = await repo.listByTimestampRange(userId.toString(), args.fromIso, args.toIso);
-    return [...activities].reverse();
+    const { activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
+    const docs = await ctx.db
+      .query('activities')
+      .withIndex('by_activityStreamId_by_timestamp', (q) =>
+        q
+          .eq('activityStreamId', activityStreamId)
+          .gte('activity.timestamp', args.fromIso)
+          .lte('activity.timestamp', args.toIso)
+      )
+      .order('desc')
+      .collect();
+    return docs.map((doc) => ({ ...doc.activity, _id: doc._id }));
   },
 });

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -188,3 +188,22 @@ export const getLast24hSummary = query({
     return await getLast24hSummaryUseCase(repo, nowMs);
   },
 });
+
+/**
+ * Get all activities for the authenticated user's family within a timestamp range.
+ * Returns activities ordered by timestamp descending (newest first).
+ * Used for day-based pagination on the home page.
+ */
+export const getActivitiesByDateRange = query({
+  args: {
+    ...SessionIdArg,
+    fromIso: v.string(),
+    toIso: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { userId, activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
+    const repo = new ConvexWebActivityRepository(ctx, activityStreamId);
+    const activities = await repo.listByTimestampRange(userId.toString(), args.fromIso, args.toIso);
+    return [...activities].reverse();
+  },
+});


### PR DESCRIPTION
## Summary
- Replaces the dual Convex subscriptions (paginated list + `getLast24hSummary`) with a single `getActivitiesByDateRange` query covering today + yesterday by default
- The Last 24h summary is now derived client-side via `useMemo` — no extra subscription, no independent loading race
- "Load More" extends the window by 1 full day at a time instead of 20 records

## Changes
| File | Change |
|------|--------|
| `services/backend/convex/web/babyTracker/activities.ts` | New `getActivitiesByDateRange(fromIso, toIso)` query |
| `apps/webapp/src/lib/daily-summary.ts` | Exported `Last24hSummary` type + `computeLast24hSummary` function |
| `apps/webapp/src/lib/daily-summary.spec.ts` | 3 new unit tests for `computeLast24hSummary` |
| `apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx` | Uses local `Last24hSummary` type instead of `FunctionReturnType` |
| `apps/webapp/src/app/app/page.tsx` | `daysBack` state, single range subscription, client-side 24h derivation, updated Load More |
| `apps/webapp/src/app/app/page.ui.spec.tsx` | Simplified mocks: single `mockRangeResults` replaces the old paginated + last24h mocks |

## Test plan
- [ ] On first load, today + yesterday's activities appear immediately (no two-phase loading)
- [ ] The Last 24h Summary card populates from the same data load — no separate skeleton flash
- [ ] "Load More" extends the list by one additional day
- [ ] Activities from 2+ days ago load correctly when Load More is clicked
- [ ] `pnpm typecheck && pnpm test` — 226 tests passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)