### PR TITLE
refactor: migrate activity timestamps to epoch milliseconds

### DIFF
--- a/apps/mobile/app/diaper-change/edit/[activityId].tsx
+++ b/apps/mobile/app/diaper-change/edit/[activityId].tsx
@@ -31,7 +31,7 @@ export default function EditDiaperChangePage() {
       }
       diaperChangeFormRef.current?.load({
         type: diaperChangeFromLiteral(diaperChange.type),
-        timestamp: DateTime.fromISO(activity.activity.timestamp),
+        timestamp: DateTime.fromMillis(activity.activity.timestamp),
       });
     }
   }, [activity?.activity]);

--- a/apps/mobile/app/feed/edit/[activityId].tsx
+++ b/apps/mobile/app/feed/edit/[activityId].tsx
@@ -31,7 +31,7 @@ export default function EditFeedPage() {
         case 'formula': {
           feedFormRef.current?.load({
             type: feed.type as FeedType.Expressed | FeedType.Formula,
-            timestamp: DateTime.fromISO(activity.activity.timestamp),
+            timestamp: DateTime.fromMillis(activity.activity.timestamp),
             volume: feed.volume.ml,
           });
           break;
@@ -39,7 +39,7 @@ export default function EditFeedPage() {
         case 'latch': {
           feedFormRef.current?.load({
             type: feed.type as FeedType.Latch,
-            timestamp: DateTime.fromISO(activity.activity.timestamp),
+            timestamp: DateTime.fromMillis(activity.activity.timestamp),
             duration: {
               left: {
                 seconds: feed.duration.left?.seconds || 0,
@@ -54,7 +54,7 @@ export default function EditFeedPage() {
         case 'solids': {
           feedFormRef.current?.load({
             type: feed.type as FeedType.Solids,
-            timestamp: DateTime.fromISO(activity.activity.timestamp),
+            timestamp: DateTime.fromMillis(activity.activity.timestamp),
             description: feed.description,
           });
           break;

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -26,7 +26,7 @@ function AppIndexPage() {
   const lastFeedTimestamp = activities?.find(
     (v) =>
       v.activity.type === ActivityType.Feed &&
-      DateTime.fromISO(v.activity.timestamp).toMillis() <= curDate.toMillis()
+      DateTime.fromMillis(v.activity.timestamp).toMillis() <= curDate.toMillis()
   )?.activity?.timestamp;
   const isLoading = activities == undefined;
   //get feed stats
@@ -54,14 +54,14 @@ function AppIndexPage() {
         f.activity.type === ActivityType.Feed &&
         f.activity.feed.type !== FeedType.Latch &&
         f.activity.feed.type !== FeedType.Solids &&
-        DateTime.fromISO(f.activity.timestamp).toMillis() >
+        DateTime.fromMillis(f.activity.timestamp).toMillis() >
           last24HrRange.from.toMillis() &&
-        DateTime.fromISO(f.activity.timestamp).toMillis() <=
+        DateTime.fromMillis(f.activity.timestamp).toMillis() <=
           last24HrRange.to.toMillis()
       ) {
         last24HourFeedsWithVol.push({
           activity: {
-            dateTime: DateTime.fromISO(f.activity.timestamp),
+            dateTime: DateTime.fromMillis(f.activity.timestamp),
             feed: { volume: { ml: f.activity.feed.volume.ml } },
           },
         });
@@ -110,7 +110,7 @@ function AppIndexPage() {
     if (!lastFeedTimestamp) return undefined;
     return timeAgo({
       curDateTime: curDate,
-      dateTime: DateTime.fromISO(lastFeedTimestamp),
+      dateTime: DateTime.fromMillis(lastFeedTimestamp),
     }).toString();
   }, [curDate, lastFeedTimestamp]);
   return (

--- a/apps/mobile/app/medical/edit/[activityId].tsx
+++ b/apps/mobile/app/medical/edit/[activityId].tsx
@@ -26,13 +26,13 @@ export default function EditMedicalPage() {
       if (medicalActivity.type === 'temperature') {
         medicalFormRef.current?.load({
           type: 'temperature',
-          timestamp: DateTime.fromISO(activity.activity.timestamp),
+          timestamp: DateTime.fromMillis(activity.activity.timestamp),
           temperature: medicalActivity.temperature.value,
         });
       } else if (medicalActivity.type === 'medicine') {
         medicalFormRef.current?.load({
           type: 'medicine',
-          timestamp: DateTime.fromISO(activity.activity.timestamp),
+          timestamp: DateTime.fromMillis(activity.activity.timestamp),
           name: medicalActivity.medicine.name,
           unit: medicalActivity.medicine.unit,
           value: medicalActivity.medicine.value,

--- a/apps/mobile/src/components/molecules/ActivityList/ActivityListViewModel.tsx
+++ b/apps/mobile/src/components/molecules/ActivityList/ActivityListViewModel.tsx
@@ -31,7 +31,7 @@ export function viewModelFromActivities(
   return list.reduce(
     (state, activity) => {
       //insert sections
-      const activityDate = DateTime.fromISO(
+      const activityDate = DateTime.fromMillis(
         activity.activity.timestamp
       ).toFormat('dd MMM yyyy');
       if (state.lastDate != activityDate) {

--- a/apps/mobile/src/components/molecules/ActivityList/index.tsx
+++ b/apps/mobile/src/components/molecules/ActivityList/index.tsx
@@ -56,7 +56,7 @@ function ActivityItem(props: {
   onPress: (e: { activity: Activity }) => void;
 }) {
   const activity = props.activity;
-  const activityTimestamp = DateTime.fromISO(activity.activity.timestamp);
+  const activityTimestamp = DateTime.fromMillis(activity.activity.timestamp);
   let icon = <></>;
   switch (activity.activity.type) {
     case ActivityType.Feed: {

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
@@ -67,7 +67,7 @@ export default function DiaperEditPage() {
 
     const dc = activity.diaperChange as Record<string, unknown> | undefined;
     const existingType = dc?.type as string;
-    const ts = activity.timestamp as string;
+    const ts = activity.timestamp as string | number;
 
     const existingRemarks = dc?.remarks as string | undefined;
     setDiaperType((existingType as DiaperType) || 'wet');

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.ui.spec.tsx
@@ -26,7 +26,7 @@ const EXISTING_DIRTY: Record<string, unknown> = {
   data: {
     _id: 'act-diaper-1',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T10:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T10:00:00.000Z'),
     type: 'diaper_change',
     diaperChange: { type: 'dirty' },
   },

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
@@ -85,7 +85,7 @@ export default function FeedEditPage() {
 
     const feed = activity.feed as Record<string, unknown> | undefined;
     const feedSubType = feed?.type as string;
-    const ts = activity.timestamp as string;
+    const ts = activity.timestamp as string | number;
 
     setFeedType((feedSubType as FeedType) || 'latch');
     setDatetime(ts ? toLocalDatetimeString(ts) : '');

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.ui.spec.tsx
@@ -109,7 +109,7 @@ function makeLatchQueryResult() {
     data: {
       _id: 'act-test-1',
       _creationTime: Date.now(),
-      timestamp: '2025-01-15T14:30:00.000Z',
+      timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
       type: 'feed',
       feed: {
         type: 'latch',
@@ -129,7 +129,7 @@ function makeBottleQueryResult() {
     data: {
       _id: 'act-test-1',
       _creationTime: Date.now(),
-      timestamp: '2025-01-15T14:30:00.000Z',
+      timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
       type: 'feed',
       feed: {
         type: 'expressed',
@@ -146,7 +146,7 @@ function makeSolidsQueryResult() {
     data: {
       _id: 'act-test-1',
       _creationTime: Date.now(),
-      timestamp: '2025-01-15T14:30:00.000Z',
+      timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
       type: 'feed',
       feed: {
         type: 'solids',

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
@@ -75,7 +75,7 @@ export default function MedicalEditPage() {
 
     const med = activity.medical as Record<string, unknown> | undefined;
     const existingType = med?.type as string;
-    const ts = activity.timestamp as string;
+    const ts = activity.timestamp as string | number;
 
     setMedicalType((existingType as MedicalType) || 'temperature');
     setDatetime(ts ? toLocalDatetimeString(ts) : '');

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.ui.spec.tsx
@@ -26,7 +26,7 @@ const EXISTING_TEMPERATURE: Record<string, unknown> = {
   data: {
     _id: 'act-med-1',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T10:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T10:00:00.000Z'),
     type: 'medical',
     medical: { type: 'temperature', temperature: { value: 37.5 } },
   },
@@ -37,7 +37,7 @@ const EXISTING_MEDICINE: Record<string, unknown> = {
   data: {
     _id: 'act-med-2',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T10:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T10:00:00.000Z'),
     type: 'medical',
     medical: { type: 'medicine', medicine: { name: 'Paracetamol', value: 5, unit: 'ml' } },
   },

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -107,8 +107,8 @@ const ACTIVITY_ICON_MAP: Record<string, React.ComponentType<{ className?: string
 export type TimeOfDay = 'midnight' | 'morning' | 'afternoon' | 'night';
 
 /** Classify a timestamp into a time-of-day bucket based on local hour. */
-function getTimeOfDay(ts: string): TimeOfDay {
-  const hour = DateTime.fromISO(ts).toLocal().hour;
+function getTimeOfDay(ts: number): TimeOfDay {
+  const hour = DateTime.fromMillis(ts).toLocal().hour;
   if (hour >= 6 && hour < 12) return 'morning';
   if (hour >= 12 && hour < 18) return 'afternoon';
   if (hour >= 18) return 'night';
@@ -181,21 +181,20 @@ export default function AppHomePage() {
 
   const [daysBack, setDaysBack] = useState(2);
 
-  const nowIso = useNowBucket5Min();
-  const nowMs = DateTime.fromISO(nowIso).toMillis();
+  const nowMs = useNowBucket5Min();
 
-  const fromIso = useMemo(() => {
+  const fromMs = useMemo(() => {
     // Load from the requested number of days back, but always at least from yesterday midnight.
     // The last-24h summary needs activities from (now - 24h), which always falls on yesterday,
     // so we must never load less than yesterday's data regardless of daysBack.
     const requestedFrom = DateTime.now().startOf('day').minus({ days: daysBack - 1 });
     const minFrom = DateTime.now().startOf('day').minus({ days: 1 }); // yesterday midnight
-    return (requestedFrom < minFrom ? requestedFrom : minFrom).toISO()!;
+    return (requestedFrom < minFrom ? requestedFrom : minFrom).toMillis();
   }, [daysBack]);
 
   const rangeResult = useSessionQuery(
     api.web.babyTracker.activities.getActivitiesByDateRange,
-    { fromIso, toIso: nowIso }
+    { fromMs, toMs: nowMs }
   );
 
   // Stale-while-revalidate: keep the last confirmed results so "Load More"
@@ -243,8 +242,8 @@ export default function AppHomePage() {
 
   const groupedByDate = useMemo(() => {
     const sorted = [...results].sort((a, b) => {
-      const tsA = DateTime.fromISO(a.timestamp).toMillis();
-      const tsB = DateTime.fromISO(b.timestamp).toMillis();
+      const tsA = a.timestamp;
+      const tsB = b.timestamp;
       return tsB - tsA;
     });
 
@@ -254,7 +253,7 @@ export default function AppHomePage() {
     }[] = [];
 
     for (const activity of sorted) {
-      const ts: string = activity.timestamp;
+      const ts = activity.timestamp;
       const dateKey = toDateKey(ts);
       const period = getTimeOfDay(ts);
 

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -43,11 +43,15 @@ vi.mock('@workspace/backend/convex/_generated/api', () => createApiMock());
 // ── Mutable query state ─────────────────────────────────────────
 
 let mockRangeResults: Record<string, unknown>[] | undefined = [];
+let lastQueryArgs: { fromMs: number; toMs: number } | undefined;
 
 vi.mock('convex-helpers/react/sessions', () => ({
   SessionProvider: ({ children }: { children: ReactNode }) => children,
   useSessionPaginatedQuery: () => undefined,
-  useSessionQuery: (_api: unknown, _args: unknown) => mockRangeResults,
+  useSessionQuery: (_api: unknown, args: { fromMs: number; toMs: number }) => {
+    lastQueryArgs = args;
+    return mockRangeResults;
+  },
 }));
 
 // ── Mutable auth state ──────────────────────────────────────────
@@ -70,6 +74,7 @@ vi.mock('@/modules/auth/AuthProvider', () => ({
 /** Reset all mutable mock state between tests. */
 function resetMocks() {
   mockRangeResults = [];
+  lastQueryArgs = undefined;
   mockRouterPush.mockClear();
   currentAuthState = {
     sessionId: 'test-session',
@@ -85,7 +90,7 @@ function makeLatchActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-1',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T14:30:00.000Z',
+    timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
     type: 'feed',
     feed: {
       type: 'latch',
@@ -100,7 +105,7 @@ function makeBottleActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-2',
     _creationTime: Date.now() - 1000,
-    timestamp: '2025-01-15T12:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T12:00:00.000Z'),
     type: 'feed',
     feed: {
       type: 'expressed',
@@ -115,7 +120,7 @@ function makeSolidsActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-3',
     _creationTime: Date.now() - 2000,
-    timestamp: '2025-01-14T18:00:00.000Z',
+    timestamp: Date.parse('2025-01-14T18:00:00.000Z'),
     type: 'feed',
     feed: {
       type: 'solids',
@@ -130,7 +135,7 @@ function makeDiaperActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-4',
     _creationTime: Date.now() - 3000,
-    timestamp: '2025-01-14T16:30:00.000Z',
+    timestamp: Date.parse('2025-01-14T16:30:00.000Z'),
     type: 'diaper_change',
     diaperChange: {
       type: 'wet',
@@ -144,7 +149,7 @@ function makeTemperatureActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-5',
     _creationTime: Date.now() - 4000,
-    timestamp: '2025-01-14T09:00:00.000Z',
+    timestamp: Date.parse('2025-01-14T09:00:00.000Z'),
     type: 'medical',
     medical: {
       type: 'temperature',
@@ -159,7 +164,7 @@ function makeMedicineActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-6',
     _creationTime: Date.now() - 5000,
-    timestamp: '2025-01-13T20:00:00.000Z',
+    timestamp: Date.parse('2025-01-13T20:00:00.000Z'),
     type: 'medical',
     medical: {
       type: 'medicine',
@@ -234,7 +239,7 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: Date.now() - 1000,
-          timestamp: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 1 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -316,10 +321,10 @@ describe('App home page', () => {
       // Jan 15 08:00 Z → SGT Jan 15 16:00 (afternoon) — local date = Jan 15.
       // Jan 15 12:00 Z → SGT Jan 15 20:00 (night) — local date = Jan 15.
       mockRangeResults = [
-        makeLatchActivity({ timestamp: '2025-01-14T15:59:59.000Z' }),
-        makeSolidsActivity({ timestamp: '2025-01-14T16:00:00.000Z' }),
-        makeBottleActivity({ timestamp: '2025-01-15T08:00:00.000Z' }),
-        makeDiaperActivity({ timestamp: '2025-01-15T12:00:00.000Z' }),
+        makeLatchActivity({ timestamp: Date.parse('2025-01-14T15:59:59.000Z') }),
+        makeSolidsActivity({ timestamp: Date.parse('2025-01-14T16:00:00.000Z') }),
+        makeBottleActivity({ timestamp: Date.parse('2025-01-15T08:00:00.000Z') }),
+        makeDiaperActivity({ timestamp: Date.parse('2025-01-15T12:00:00.000Z') }),
       ];
 
       render(<AppHomePage />);
@@ -523,7 +528,7 @@ describe('App home page', () => {
         {
           _id: 'act-yesterday',
           _creationTime: Date.now() - 86400000,
-          timestamp: '2025-05-18T10:00:00.000Z',
+          timestamp: Date.parse('2025-05-18T10:00:00.000Z'),
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -548,7 +553,7 @@ describe('App home page', () => {
         {
           _id: 'act-today',
           _creationTime: Date.now(),
-          timestamp: '2025-05-19T08:00:00.000Z',
+          timestamp: Date.parse('2025-05-19T08:00:00.000Z'),
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -569,21 +574,21 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 60 } },
         },
         {
           _id: 'b2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 90 } },
         },
         {
           _id: 'b3',
           _creationTime: now - 3000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'feed',
           feed: { type: 'formula', volume: { ml: 120 } },
         },
@@ -607,14 +612,14 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 60 } },
         },
         {
           _id: 'b2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 90 } },
         },
@@ -636,14 +641,14 @@ describe('App home page', () => {
         {
           _id: 'l1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'latch', duration: { left: { seconds: 600 }, right: { seconds: 300 } } },
         },
         {
           _id: 'l2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'feed',
           feed: { type: 'latch', duration: { left: { seconds: 900 }, right: { seconds: 450 } } },
         },
@@ -665,21 +670,21 @@ describe('App home page', () => {
         {
           _id: 's1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'solids', description: 'Banana' },
         },
         {
           _id: 's2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'feed',
           feed: { type: 'solids', description: 'banana' },
         },
         {
           _id: 's3',
           _creationTime: now - 3000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'feed',
           feed: { type: 'solids', description: 'Rice' },
         },
@@ -701,21 +706,21 @@ describe('App home page', () => {
         {
           _id: 'd1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
         {
           _id: 'd2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
         {
           _id: 'd3',
           _creationTime: now - 3000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'mixed' },
         },
@@ -741,7 +746,7 @@ describe('App home page', () => {
         {
           _id: 'd1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
@@ -762,14 +767,14 @@ describe('App home page', () => {
         {
           _id: 'm1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'medical',
           medical: { type: 'temperature', temperature: { value: 37.8 } },
         },
         {
           _id: 'm2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 5 * hour).toISOString(),
+          timestamp: now - 5 * hour,
           type: 'medical',
           medical: { type: 'temperature', temperature: { value: 37.0 } },
         },
@@ -792,14 +797,14 @@ describe('App home page', () => {
         {
           _id: 'med1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'ml', value: 5 } },
         },
         {
           _id: 'med2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'ml', value: 5 } },
         },
@@ -821,14 +826,14 @@ describe('App home page', () => {
         {
           _id: 'med1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'ml', value: 5 } },
         },
         {
           _id: 'med2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'g', value: 0.5 } },
         },
@@ -850,7 +855,7 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -881,7 +886,7 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: Date.now() - 1000,
-          timestamp: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 1 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -904,7 +909,7 @@ describe('App home page', () => {
         {
           _id: 'd-yesterday',
           _creationTime: now - 25 * hour,
-          timestamp: new Date(now - 25 * hour).toISOString(), // 25h ago = yesterday
+          timestamp: now - 25 * hour, // 25h ago = yesterday
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
@@ -912,7 +917,7 @@ describe('App home page', () => {
         {
           _id: 'b-today',
           _creationTime: now - hour,
-          timestamp: new Date(now - hour).toISOString(),
+          timestamp: now - hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -942,7 +947,7 @@ describe('App home page', () => {
         {
           _id: 'd-yesterday',
           _creationTime: Date.now() - 20 * 3600 * 1000,
-          timestamp: '2025-05-18T14:00:00.000Z',
+          timestamp: Date.parse('2025-05-18T14:00:00.000Z'),
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
@@ -968,7 +973,7 @@ describe('App home page', () => {
         {
           _id: 't-yesterday',
           _creationTime: Date.now() - 20 * 3600 * 1000,
-          timestamp: '2025-05-18T14:00:00.000Z',
+          timestamp: Date.parse('2025-05-18T14:00:00.000Z'),
           type: 'medical',
           medical: { type: 'temperature', temperature: { value: 37.5 } },
         },
@@ -1058,7 +1063,7 @@ describe('App home page', () => {
         {
           _id: 'feed-20h-ago',
           _creationTime: Date.now() - 20 * 3600 * 1000,
-          timestamp: new Date(Date.now() - 20 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 20 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 150 } },
         },
@@ -1076,7 +1081,7 @@ describe('App home page', () => {
         {
           _id: 'feed-25h-ago',
           _creationTime: Date.now() - 25 * 3600 * 1000,
-          timestamp: new Date(Date.now() - 25 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 25 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 200 } },
         },
@@ -1096,7 +1101,7 @@ describe('App home page', () => {
         {
           _id: 'diaper-23h-ago',
           _creationTime: Date.now() - 23 * 3600 * 1000,
-          timestamp: new Date(Date.now() - 23 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 23 * 3600 * 1000,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
@@ -1110,6 +1115,48 @@ describe('App home page', () => {
       expect(within(last24hSection).getByText('Wet:')).toBeInTheDocument();
       const wetLabel = within(last24hSection).getByText('Wet:');
       expect(wetLabel.nextElementSibling?.textContent).toBe('1');
+    });
+  });
+
+  // ── 13. Regression: fromIso timezone (UTC format) ──────────────────
+  //
+  // Regression for: fromIso used DateTime.toISO() which preserved the
+  // local timezone offset (e.g., "+08:00"), but activity timestamps in
+  // Convex are stored as UTC ISO strings ending in "Z". String comparison
+  // in the index would fail, causing yesterday's early records to be
+  // excluded. Fix: add .toUTC() before .toISO() to normalize the format.
+
+  describe('regression: fromMs represents yesterday midnight in the local zone', () => {
+    const originalTz = process.env.TZ;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      process.env.TZ = 'Asia/Singapore';
+      vi.setSystemTime(new Date('2025-05-21T10:00:00.000Z')); // 18:00 SGT
+      mockRangeResults = [makeLatchActivity({ _id: 'act-tz-test' })];
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      process.env.TZ = originalTz;
+    });
+
+    it('fromMs is a number (epoch ms)', () => {
+      render(<AppHomePage />);
+
+      expect(lastQueryArgs).toBeTruthy();
+      expect(typeof lastQueryArgs!.fromMs).toBe('number');
+      expect(lastQueryArgs!.fromMs).toBeGreaterThan(1_700_000_000_000);
+    });
+
+    it('fromMs represents yesterday midnight SGT in epoch ms', () => {
+      // System time: May 21 10:00 UTC = May 21 18:00 SGT (UTC+8)
+      // yesterday midnight SGT = May 20 00:00 SGT = May 19 16:00 UTC
+      render(<AppHomePage />);
+
+      // May 19 16:00 UTC in epoch ms
+      const expectedMs = Date.UTC(2025, 4, 19, 16, 0, 0, 0); // month is 0-indexed
+      expect(lastQueryArgs!.fromMs).toBe(expectedMs);
     });
   });
 });

--- a/apps/webapp/src/lib/activity-form-utils.spec.ts
+++ b/apps/webapp/src/lib/activity-form-utils.spec.ts
@@ -5,7 +5,7 @@
  * for both Z-suffixed (UTC) and offset-suffixed (+08:00) ISO inputs.
  */
 import { describe, expect, it, beforeAll } from 'vitest';
-import { Settings as LuxonSettings } from 'luxon';
+import { DateTime, Settings as LuxonSettings } from 'luxon';
 
 // Pin timezone to UTC+8 for reproducible date boundary tests
 beforeAll(() => {
@@ -17,18 +17,25 @@ import { toDateKey } from './activity-form-utils';
 describe('toDateKey — timezone handling', () => {
   it('Case A: +08:00 early-morning timestamp → correct local day', () => {
     // 04:30 AM on 19 May in Singapore = 20:30 UTC previous day
-    const result = toDateKey('2026-05-19T04:30:00+08:00');
+    const result = toDateKey(DateTime.fromISO('2026-05-19T04:30:00+08:00'));
     expect(result).toBe('2026-05-19');
   });
 
   it('Case B: equivalent Z (UTC) timestamp → same local day in UTC+8', () => {
     // 20:30 UTC = 04:30 SGT the next calendar day
-    const result = toDateKey('2026-05-18T20:30:00.000Z');
+    const result = toDateKey(DateTime.fromISO('2026-05-18T20:30:00.000Z'));
     expect(result).toBe('2026-05-19');
   });
 
   it('Case C: late-evening +08:00 timestamp → same local day', () => {
-    const result = toDateKey('2026-05-19T23:30:00+08:00');
+    const result = toDateKey(DateTime.fromISO('2026-05-19T23:30:00+08:00'));
+    expect(result).toBe('2026-05-19');
+  });
+
+  it('Case D: epoch ms timestamp → correct local day', () => {
+    // 04:30 SGT on May 19 = 2026-05-18T20:30:00.000Z
+    const ms = Date.UTC(2026, 4, 18, 20, 30, 0, 0); // May 18 20:30 UTC
+    const result = toDateKey(ms);
     expect(result).toBe('2026-05-19');
   });
 });

--- a/apps/webapp/src/lib/activity-form-utils.ts
+++ b/apps/webapp/src/lib/activity-form-utils.ts
@@ -13,12 +13,13 @@ export function getDefaultDatetime(): string {
 }
 
 /**
- * Converts an ISO timestamp (UTC or offset) to a local "YYYY-MM-DDTHH:MM" string
+ * Converts an ISO timestamp (UTC or offset) or epoch ms to a local "YYYY-MM-DDTHH:MM" string
  * for use as the value of a datetime-local input.
  * Mirrors how the mobile pre-populates edit forms.
  */
-export function toLocalDatetimeString(isoTs: string): string {
-  return DateTime.fromISO(isoTs).toLocal().toFormat("yyyy-MM-dd'T'HH:mm");
+export function toLocalDatetimeString(isoTsOrMs: string | number): string {
+  const dt = typeof isoTsOrMs === 'number' ? DateTime.fromMillis(isoTsOrMs) : DateTime.fromISO(isoTsOrMs);
+  return dt.toLocal().toFormat("yyyy-MM-dd'T'HH:mm");
 }
 
 /**
@@ -50,14 +51,14 @@ export function formatDuration(totalSeconds: number): string {
   return `${minutes} min ${seconds} sec`;
 }
 
-/** Formats an ISO timestamp to a short time like "2:30 PM" using Luxon in local time. */
-export function formatTime(ts: string): string {
-  return DateTime.fromISO(ts).toLocal().toFormat('h:mm a');
+/** Formats an epoch ms timestamp to a short time like "2:30 PM" using Luxon in local time. */
+export function formatTime(ts: number): string {
+  return DateTime.fromMillis(ts).toLocal().toFormat('h:mm a');
 }
 
 /** Formats a timestamp to a locale date string like "Jan 15, 2025" using Luxon in local time. */
-export function formatDate(ts: string): string {
-  return DateTime.fromISO(ts).toLocal().toFormat('MMM d, yyyy');
+export function formatDate(ts: number): string {
+  return DateTime.fromMillis(ts).toLocal().toFormat('MMM d, yyyy');
 }
 
 /**

--- a/apps/webapp/src/lib/daily-summary.spec.ts
+++ b/apps/webapp/src/lib/daily-summary.spec.ts
@@ -21,19 +21,19 @@ function referenceTime(iso: string, zone = 'local') {
 // ── Activity factories ───────────────────────────────────────────────────────
 
 function makeFeed(ts: string, subType: string, extras: Record<string, unknown> = {}) {
-  return { type: 'feed' as const, timestamp: ts, feed: { type: subType, ...extras } };
+  return { type: 'feed' as const, timestamp: Date.parse(ts), feed: { type: subType, ...extras } };
 }
 
 function makeDiaper(ts: string, diaperType: string) {
-  return { type: 'diaper_change' as const, timestamp: ts, diaperChange: { type: diaperType } };
+  return { type: 'diaper_change' as const, timestamp: Date.parse(ts), diaperChange: { type: diaperType } };
 }
 
 function makeTemp(ts: string, value: number) {
-  return { type: 'medical' as const, timestamp: ts, medical: { type: 'temperature' as const, temperature: { value } } };
+  return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'temperature' as const, temperature: { value } } };
 }
 
 function makeMedicine(ts: string, name: string, unit: string, value: number) {
-  return { type: 'medical' as const, timestamp: ts, medical: { type: 'medicine' as const, medicine: { name, unit, value } } };
+  return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'medicine' as const, medicine: { name, unit, value } } };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -137,9 +137,9 @@ describe('computeDailySummary', () => {
         lastWetAgoMs: expect.any(Number),
         lastDirtyAgoMs: expect.any(Number),
         lastMixedAgoMs: expect.any(Number),
-        lastWetAt: twoHoursAgo,
-        lastDirtyAt: eightHoursAgo,
-        lastMixedAt: sixHoursAgo,
+        lastWetAt: Date.parse(twoHoursAgo),
+        lastDirtyAt: Date.parse(eightHoursAgo),
+        lastMixedAt: Date.parse(sixHoursAgo),
       });
 
       const lastWetAgo = result.diapers!.lastWetAgoMs!;
@@ -177,7 +177,7 @@ describe('computeDailySummary', () => {
       expect(result.medical!.latestTemperature).toEqual({
         valueC: 37.5,
         agoMs: expect.any(Number),
-        at: nineAmJan15,
+        at: Date.parse(nineAmJan15),
       });
       expect(result.medical!.medicines).toHaveLength(2);
 
@@ -257,7 +257,7 @@ describe('computeDailySummary', () => {
         { type: 'feed' }, // completely malformed — missing timestamp, filtered out
         null,
         { type: 'diaper_change', timestamp: 'invalid-ts' }, // unparseable timestamp
-        { type: 'feed', timestamp: '2025-01-15T08:00:00.000Z', feed: { type: 'water' } }, // valid timestamp, water feed = bottle total 0, count 1
+        { type: 'feed', timestamp: Date.parse('2025-01-15T08:00:00.000Z'), feed: { type: 'water' } }, // valid timestamp, water feed = bottle total 0, count 1
       ];
 
       const result = computeDailySummary(activities as readonly unknown[], { ...range, referenceTime: ref });
@@ -402,7 +402,7 @@ describe('computeDailySummariesByDay', () => {
     expect(result[0].dayStart.toISO()).toBe('2025-01-15T00:00:00.000Z');
   });
 
-  it('latestTemperature.at is an ISO string when day has non-medical activity', () => {
+  it('latestTemperature.at is an epoch ms number when day has non-medical activity', () => {
     vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
     const ref = DateTime.utc();
 
@@ -415,7 +415,7 @@ describe('computeDailySummariesByDay', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].summary.hasAny).toBe(true);
-    expect(result[0].summary.medical?.latestTemperature?.at).toBe('2025-01-15T10:00:00.000Z');
+    expect(result[0].summary.medical?.latestTemperature?.at).toBe(Date.parse('2025-01-15T10:00:00.000Z'));
   });
 });
 

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -17,7 +17,7 @@ type MedicalSubType = 'temperature' | 'medicine';
 
 interface FeedActivity {
   type: 'feed';
-  timestamp: string;
+  timestamp: number;
   feed: {
     type: FeedSubType;
     duration?: { left?: { seconds?: number }; right?: { seconds?: number } };
@@ -28,13 +28,13 @@ interface FeedActivity {
 
 interface DiaperActivity {
   type: 'diaper_change';
-  timestamp: string;
+  timestamp: number;
   diaperChange: { type: DiaperSubType };
 }
 
 interface MedicalActivity {
   type: 'medical';
-  timestamp: string;
+  timestamp: number;
   medical: {
     type: MedicalSubType;
     temperature?: { value?: number };
@@ -47,11 +47,11 @@ export type Activity = FeedActivity | DiaperActivity | MedicalActivity;
 // ── Date-key helper (shared with callers) ─────────────────────────────────────
 
 /**
- * Formats a DateTime or ISO timestamp string as `YYYY-MM-DD` in the local zone.
+ * Formats a DateTime or epoch ms timestamp as `YYYY-MM-DD` in the local zone.
  * Used to derive `dateKey` for grouping activities by day.
  */
-export function toDateKey(input: string | DateTime, zone: string = 'local'): string {
-  const dt = typeof input === 'string' ? DateTime.fromISO(input, { zone }) : input.setZone(zone);
+export function toDateKey(input: number | DateTime, zone: string = 'local'): string {
+  const dt = typeof input === 'number' ? DateTime.fromMillis(input, { zone }) : input.setZone(zone);
   return dt.toLocal().toFormat('yyyy-MM-dd');
 }
 
@@ -72,16 +72,16 @@ export interface DailySummary {
     lastWetAgoMs: number | null;
     lastDirtyAgoMs: number | null;
     lastMixedAgoMs: number | null;
-    lastWetAt: string | null;
-    lastDirtyAt: string | null;
-    lastMixedAt: string | null;
+    lastWetAt: number | null;
+    lastDirtyAt: number | null;
+    lastMixedAt: number | null;
   } | null;
   /**
    * Medical aggregation is computed but NOT rendered by DailySummaryCard
    * (intentional — re-enabling the UI is a render-only change).
    */
   medical: {
-    latestTemperature: { valueC: number; agoMs: number; at: string } | null;
+    latestTemperature: { valueC: number; agoMs: number; at: number } | null;
     medicines: Array<{
       name: string;
       unit: string;
@@ -126,15 +126,15 @@ export function computeDailySummary(
     const act = parseActivity(a);
     if (!act) continue;
     const ts = act.timestamp;
-    if (!ts) continue;
-    const dt = DateTime.fromISO(ts, { zone });
+    if (typeof ts !== 'number') continue;
+    const dt = DateTime.fromMillis(ts, { zone });
     if (!dt.isValid) continue;
     if (dt < dayStart || dt > dayEnd) continue;
     todaysActivities.push(act);
   }
 
   // Sort by timestamp ascending (needed for stable "last seen" tracking)
-  todaysActivities.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  todaysActivities.sort((a, b) => a.timestamp - b.timestamp);
 
   // Aggregate feed
   let bottleTotalMl = 0;
@@ -148,13 +148,13 @@ export function computeDailySummary(
   let wetCount = 0;
   let dirtyCount = 0;
   let mixedCount = 0;
-  let lastWetTs: string | null = null;
-  let lastDirtyTs: string | null = null;
-  let lastMixedTs: string | null = null;
+  let lastWetTs: number | null = null;
+  let lastDirtyTs: number | null = null;
+  let lastMixedTs: number | null = null;
 
   // Aggregate medical
   let latestTempValue: number | null = null;
-  let latestTempTs: string | null = null;
+  let latestTempTs: number | null = null;
   const medicineMap = new Map<
     string,
     { name: string; unit: string; totalValue: number; count: number; mixedUnits: boolean }
@@ -250,13 +250,13 @@ export function computeDailySummary(
           mixed: mixedCount,
           total: wetCount + dirtyCount + mixedCount,
           lastWetAgoMs: lastWetTs
-            ? referenceTime.toMillis() - DateTime.fromISO(lastWetTs, { zone }).toMillis()
+            ? referenceTime.toMillis() - lastWetTs
             : null,
           lastDirtyAgoMs: lastDirtyTs
-            ? referenceTime.toMillis() - DateTime.fromISO(lastDirtyTs, { zone }).toMillis()
+            ? referenceTime.toMillis() - lastDirtyTs
             : null,
           lastMixedAgoMs: lastMixedTs
-            ? referenceTime.toMillis() - DateTime.fromISO(lastMixedTs, { zone }).toMillis()
+            ? referenceTime.toMillis() - lastMixedTs
             : null,
           lastWetAt: lastWetTs,
           lastDirtyAt: lastDirtyTs,
@@ -268,7 +268,7 @@ export function computeDailySummary(
     latestTempValue !== null && latestTempTs !== null
       ? {
           valueC: latestTempValue,
-          agoMs: referenceTime.toMillis() - DateTime.fromISO(latestTempTs, { zone }).toMillis(),
+          agoMs: referenceTime.toMillis() - latestTempTs,
           at: latestTempTs,
         }
       : null;
@@ -323,8 +323,8 @@ export function computeDailySummariesByDay(
   const dayMap = new Map<string, unknown[]>();
   for (const a of activities) {
     const act = parseActivity(a);
-    if (!act || !act.timestamp) continue;
-    const dt = DateTime.fromISO(act.timestamp, { zone });
+    if (!act || typeof act.timestamp !== 'number') continue;
+    const dt = DateTime.fromMillis(act.timestamp, { zone });
     if (!dt.isValid) continue;
     const key = toDateKey(dt);
     if (!dayMap.has(key)) dayMap.set(key, []);
@@ -385,7 +385,7 @@ export function computeLast24hSummary(
   let wet = 0, dirty = 0, mixed = 0;
 
   for (const activity of activities) {
-    const tsMs = Date.parse(activity.timestamp);
+    const tsMs = activity.timestamp;
     if (tsMs <= nowMs && tsMs > windowStartMs) {
       if (activity.type === 'feed') {
         if (tsMs > (lastFeedAtMs ?? 0)) lastFeedAtMs = tsMs;

--- a/apps/webapp/src/lib/use-now-bucket.spec.ts
+++ b/apps/webapp/src/lib/use-now-bucket.spec.ts
@@ -31,9 +31,10 @@ describe('useNowBucket5Min', () => {
     vi.useRealTimers();
   });
 
-  it('returns ISO string with UTC zone', () => {
+  it('returns epoch ms number', () => {
     vi.setSystemTime(new Date('2025-01-15T12:03:00.000Z'));
     const { result } = renderHook(() => useNowBucket5Min());
-    expect(result.current).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$/);
+    expect(typeof result.current).toBe('number');
+    expect(result.current).toBeGreaterThan(1_700_000_000_000);
   });
 });

--- a/apps/webapp/src/lib/use-now-bucket.ts
+++ b/apps/webapp/src/lib/use-now-bucket.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { DateTime } from 'luxon';
 
 export function roundUpToNext5Min(ms: number): number {
   const boundary = Math.ceil(ms / 300_000) * 300_000;
@@ -7,7 +6,7 @@ export function roundUpToNext5Min(ms: number): number {
   return boundary;
 }
 
-export function useNowBucket5Min(): string {
+export function useNowBucket5Min(): number {
   const [bucket, setBucket] = useState<number>(() => roundUpToNext5Min(Date.now()));
 
   useEffect(() => {
@@ -25,5 +24,5 @@ export function useNowBucket5Min(): string {
     return () => clearTimeout(timerId);
   }, []);
 
-  return DateTime.fromMillis(bucket, { zone: 'utc' }).toISO()!;
+  return bucket;
 }

--- a/apps/webapp/src/modules/baby-tracker/DailySummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/DailySummaryCard.spec.tsx
@@ -83,7 +83,7 @@ describe('DailySummaryCard', () => {
           lastWetAgoMs: 3_600_000,
           lastDirtyAgoMs: null,
           lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T08:00:00.000Z',
+          lastWetAt: Date.parse('2025-01-15T08:00:00.000Z'),
           lastDirtyAt: null,
           lastMixedAt: null,
         },
@@ -109,8 +109,8 @@ describe('DailySummaryCard', () => {
           lastWetAgoMs: 7_200_000,
           lastDirtyAgoMs: 5_400_000,
           lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T08:00:00.000Z',
-          lastDirtyAt: '2025-01-15T10:00:00.000Z',
+          lastWetAt: Date.parse('2025-01-15T08:00:00.000Z'),
+          lastDirtyAt: Date.parse('2025-01-15T10:00:00.000Z'),
           lastMixedAt: null,
         },
         medical: null,
@@ -133,8 +133,8 @@ describe('DailySummaryCard', () => {
           lastDirtyAgoMs: 10_800_000,
           lastMixedAgoMs: 5_400_000,
           lastWetAt: null,
-          lastDirtyAt: '2025-01-15T10:00:00.000Z',
-          lastMixedAt: '2025-01-15T08:00:00.000Z',
+          lastDirtyAt: Date.parse('2025-01-15T10:00:00.000Z'),
+          lastMixedAt: Date.parse('2025-01-15T08:00:00.000Z'),
         },
         medical: null,
       };
@@ -151,7 +151,7 @@ describe('DailySummaryCard', () => {
         diapers: {
           wet: 1, dirty: 0, mixed: 0, total: 1,
           lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T10:00:00.000Z', lastDirtyAt: null, lastMixedAt: null,
+          lastWetAt: Date.parse('2025-01-15T10:00:00.000Z'), lastDirtyAt: null, lastMixedAt: null,
         },
         medical: null,
       };
@@ -166,7 +166,7 @@ describe('DailySummaryCard', () => {
         diapers: {
           wet: 1, dirty: 0, mixed: 0, total: 1,
           lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T10:30:00.000Z', lastDirtyAt: null, lastMixedAt: null,
+          lastWetAt: Date.parse('2025-01-15T10:30:00.000Z'), lastDirtyAt: null, lastMixedAt: null,
         },
         medical: null,
       };
@@ -180,7 +180,7 @@ describe('DailySummaryCard', () => {
       const summary: DailySummary = {
         hasAny: true,
         feed: { bottle: null, latch: null, solids: null },
-        diapers: { wet: 2, dirty: 0, mixed: 0, total: 2, lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null, lastWetAt: '2025-05-19T10:00:00.000Z', lastDirtyAt: null, lastMixedAt: null },
+        diapers: { wet: 2, dirty: 0, mixed: 0, total: 2, lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null, lastWetAt: Date.parse('2025-05-19T10:00:00.000Z'), lastDirtyAt: null, lastMixedAt: null },
         medical: null,
       };
       render(<DailySummaryCard summary={summary} isToday={true} />);

--- a/services/backend/convex/migrations.ts
+++ b/services/backend/convex/migrations.ts
@@ -63,7 +63,7 @@ export const setUserAccessLevelDefault = migrations.define({
 export const fixWebappTimestampsToUtcPlus8 = migrations.define({
   table: 'activities',
   migrateOne: async (_ctx, doc) => {
-    const ts = doc.activity.timestamp;
+    const ts = doc.activity.timestamp as unknown as string;
     // Skip records that already have a timezone offset (mobile-created or already migrated)
     if (!ts.endsWith('Z')) return;
 
@@ -81,6 +81,20 @@ export const fixWebappTimestampsToUtcPlus8 = migrations.define({
   },
 });
 
+/**
+ * Migration: Convert activity timestamps from ISO strings to epoch milliseconds.
+ * Handles both "Z" suffix and "+08:00" offset formats (mixed in DB).
+ */
+export const convertTimestampsToEpochMs = migrations.define({
+  table: 'activities',
+  migrateOne: async (_ctx, doc) => {
+    const ts = doc.activity.timestamp;
+    if (typeof ts === 'number') return;
+    const epochMs = DateTime.fromISO(ts as string).toMillis();
+    return { activity: { ...(doc.activity as any), timestamp: epochMs } };
+  },
+});
+
 
 /**
  * Run all migrations in order.
@@ -90,5 +104,6 @@ export const runAll = migrations.runner([
   internal.migrations.unsetSessionExpiration,
   internal.migrations.setUserAccessLevelDefault,
   internal.migrations.fixWebappTimestampsToUtcPlus8,
+  internal.migrations.convertTimestampsToEpochMs,
 ]);
 

--- a/services/backend/convex/schema.ts
+++ b/services/backend/convex/schema.ts
@@ -12,7 +12,7 @@ export default defineSchema({
     activity: v.union(
       //feed activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('feed'),
         feed: v.union(
           v.object({
@@ -44,7 +44,7 @@ export default defineSchema({
       }),
       //diaper change activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('diaper_change'),
         diaperChange: v.object({
           type: v.union(
@@ -57,7 +57,7 @@ export default defineSchema({
       }),
       // medical activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('medical'),
         medical: v.union(
           v.object({

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -96,7 +96,7 @@ export const create = mutation({
   handler: async (ctx, args) => {
     const { userId, activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
     const repo = new ConvexWebActivityRepository(ctx, activityStreamId);
-    const activityId = await createActivityUseCase(repo, userId.toString(), args.activity);
+    const activityId = await createActivityUseCase(repo, userId.toString(), args.activity as any);
     return { activityId };
   },
 });
@@ -113,7 +113,7 @@ export const update = mutation({
   handler: async (ctx, args) => {
     const { userId, activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
     const repo = new ConvexWebActivityRepository(ctx, activityStreamId);
-    await updateActivityUseCase(repo, userId.toString(), args.activityId.toString(), args.activity);
+    await updateActivityUseCase(repo, userId.toString(), args.activityId.toString(), args.activity as any);
   },
 });
 
@@ -197,8 +197,8 @@ export const getLast24hSummary = query({
 export const getActivitiesByDateRange = query({
   args: {
     ...SessionIdArg,
-    fromIso: v.string(),
-    toIso: v.string(),
+    fromMs: v.number(),
+    toMs: v.number(),
   },
   handler: async (ctx, args) => {
     const { activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
@@ -207,8 +207,8 @@ export const getActivitiesByDateRange = query({
       .withIndex('by_activityStreamId_by_timestamp', (q) =>
         q
           .eq('activityStreamId', activityStreamId)
-          .gte('activity.timestamp', args.fromIso)
-          .lte('activity.timestamp', args.toIso)
+          .gte('activity.timestamp', args.fromMs)
+          .lte('activity.timestamp', args.toMs)
       )
       .order('desc')
       .collect();

--- a/services/backend/src/domain/activity/Activity.ts
+++ b/services/backend/src/domain/activity/Activity.ts
@@ -54,19 +54,19 @@ export type MedicalPayload = TemperaturePayload | MedicinePayload;
 export type ActivityType = 'feed' | 'diaper_change' | 'medical';
 
 export interface FeedActivity {
-  timestamp: string;
+  timestamp: number;
   type: 'feed';
   feed: FeedPayload;
 }
 
 export interface DiaperChangeActivity {
-  timestamp: string;
+  timestamp: number;
   type: 'diaper_change';
   diaperChange: DiaperChangePayload;
 }
 
 export interface MedicalActivity {
-  timestamp: string;
+  timestamp: number;
   type: 'medical';
   medical: MedicalPayload;
 }

--- a/services/backend/src/domain/repositories/IActivityRepository.ts
+++ b/services/backend/src/domain/repositories/IActivityRepository.ts
@@ -46,13 +46,13 @@ export interface IActivityRepository {
   ): Promise<PaginationResult<Activity>>;
 
   /**
-   * List activities whose timestamp falls within [fromIso, toIso] (inclusive),
+   * List activities whose timestamp falls within [fromMs, toMs] (inclusive),
    * ordered by timestamp ascending. Returns ALL matching activities (no pagination).
    * Intended for bounded windows like "last 24h".
    */
   listByTimestampRange(
     deviceId: string,
-    fromIso: string,
-    toIso: string
+    fromMs: number,
+    toMs: number
   ): Promise<Activity[]>;
 }

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { computeLast24hSummary, type Last24hSummary } from './ComputeLast24hSummary';
 
 function makeFeed(ts: string, subType: string, extras: Record<string, unknown> = {}) {
-  return { type: 'feed' as const, timestamp: ts, feed: { type: subType, ...extras } };
+  return { type: 'feed' as const, timestamp: Date.parse(ts), feed: { type: subType, ...extras } };
 }
 
 function makeDiaper(ts: string, diaperType: string) {
-  return { type: 'diaper_change' as const, timestamp: ts, diaperChange: { type: diaperType } };
+  return { type: 'diaper_change' as const, timestamp: Date.parse(ts), diaperChange: { type: diaperType } };
 }
 
 function makeTemp(ts: string, value: number) {
-  return { type: 'medical' as const, timestamp: ts, medical: { type: 'temperature' as const, temperature: { value } } };
+  return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'temperature' as const, temperature: { value } } };
 }
 
 describe('computeLast24hSummary', () => {

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
@@ -34,7 +34,7 @@ export function computeLast24hSummary(
   const threeHourBoundaryMs = nowMs - 3 * 60 * 60 * 1000;
 
   for (const activity of activities) {
-    const tsMs = Date.parse(activity.timestamp);
+    const tsMs = activity.timestamp;
     if (tsMs <= nowMs && tsMs > windowStartMs) {
       if (activity.type === 'feed') {
         if (tsMs > (lastFeedAtMs ?? 0)) {

--- a/services/backend/src/domain/usecases/activity/CreateActivity.ts
+++ b/services/backend/src/domain/usecases/activity/CreateActivity.ts
@@ -11,12 +11,12 @@ export async function createActivity(
   deviceId: string,
   activity: Activity
 ): Promise<string> {
-  const ts = DateTime.fromISO(activity.timestamp);
+  const ts = DateTime.fromISO(String(activity.timestamp));
   if (!ts.isValid) {
     throw new Error(`invalid timestamp: ${activity.timestamp}`);
   }
   return repo.create(deviceId, {
     ...activity,
-    timestamp: ts.toUTC().toISO()!,
+    timestamp: ts.toMillis(),
   });
 }

--- a/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
@@ -1,14 +1,11 @@
-import { DateTime } from 'luxon';
 import type { IActivityRepository } from '../../repositories/IActivityRepository';
-import type { Last24hSummary } from './ComputeLast24hSummary';
-import { computeLast24hSummary } from './ComputeLast24hSummary';
+import { computeLast24hSummary, type Last24hSummary } from './ComputeLast24hSummary';
 
 export async function getLast24hSummary(
   repo: IActivityRepository,
   nowMs: number
 ): Promise<Last24hSummary> {
-  const fromIso = DateTime.fromMillis(nowMs - 24 * 60 * 60 * 1000).toISO()!;
-  const toIso = DateTime.fromMillis(nowMs).toISO()!;
-  const activities = await repo.listByTimestampRange('', fromIso, toIso);
+  const fromMs = nowMs - 24 * 60 * 60 * 1000;
+  const activities = await repo.listByTimestampRange('', fromMs, nowMs);
   return computeLast24hSummary(activities, nowMs);
 }

--- a/services/backend/src/domain/usecases/activity/UpdateActivity.ts
+++ b/services/backend/src/domain/usecases/activity/UpdateActivity.ts
@@ -12,12 +12,12 @@ export async function updateActivity(
   activityId: string,
   activity: Activity
 ): Promise<void> {
-  const ts = DateTime.fromISO(activity.timestamp);
+  const ts = DateTime.fromISO(String(activity.timestamp));
   if (!ts.isValid) {
     throw new Error(`invalid timestamp: ${activity.timestamp}`);
   }
   await repo.update(deviceId, activityId, {
     ...activity,
-    timestamp: ts.toUTC().toISO()!,
+    timestamp: ts.toMillis(),
   });
 }

--- a/services/backend/src/infra/ConvexActivityRepository.ts
+++ b/services/backend/src/infra/ConvexActivityRepository.ts
@@ -84,8 +84,8 @@ export class ConvexActivityRepository implements IActivityRepository {
 
   async listByTimestampRange(
     deviceId: string,
-    fromIso: string,
-    toIso: string
+    fromMs: number,
+    toMs: number
   ): Promise<Activity[]> {
     const stream = await activityStreamForDevice(this.ctx, { deviceId });
     if (!stream) {
@@ -96,8 +96,8 @@ export class ConvexActivityRepository implements IActivityRepository {
       .withIndex('by_activityStreamId_by_timestamp', (q) =>
         q
           .eq('activityStreamId', stream._id)
-          .gte('activity.timestamp', fromIso)
-          .lte('activity.timestamp', toIso)
+          .gte('activity.timestamp', fromMs)
+          .lte('activity.timestamp', toMs)
       )
       .order('asc')
       .collect();

--- a/services/backend/src/infra/ConvexWebActivityRepository.ts
+++ b/services/backend/src/infra/ConvexWebActivityRepository.ts
@@ -114,20 +114,20 @@ export class ConvexWebActivityRepository implements IActivityRepository {
 
   /**
    * List ALL activities in the repository's activity stream whose timestamp
-   * falls within [fromIso, toIso] (inclusive), ordered by timestamp ascending.
+   * falls within [fromMs, toMs] (inclusive), ordered by timestamp ascending.
    */
   async listByTimestampRange(
     _deviceId: string,
-    fromIso: string,
-    toIso: string
+    fromMs: number,
+    toMs: number
   ): Promise<Activity[]> {
     const docs = await this.ctx.db
       .query('activities')
       .withIndex('by_activityStreamId_by_timestamp', (q) =>
         q
           .eq('activityStreamId', this.activityStreamId)
-          .gte('activity.timestamp', fromIso)
-          .lte('activity.timestamp', toIso)
+          .gte('activity.timestamp', fromMs)
+          .lte('activity.timestamp', toMs)
       )
       .order('asc')
       .collect();


### PR DESCRIPTION
## Summary
- **Migrate `activity.timestamp`** from `v.string()` (ISO format) to `v.number()` (epoch ms) across the entire stack
- **Eliminates recurring timezone bugs** where string comparison in Convex indexes failed on mixed UTC/offset formats
- **Includes data migration** (`convertTimestampsToEpochMs`) that handles both `Z` and `+08:00` formats in existing records

## Changes (33 files)

### Backend
- `schema.ts`: 3× `timestamp: v.string()` → `v.number()`
- `Activity.ts`: Domain type `timestamp: string` → `number`
- `CreateActivity`/`UpdateActivity`: Store `ts.toMillis()` instead of `ts.toUTC().toISO()!`
- `getActivitiesByDateRange`: Args `fromIso/toIso` → `fromMs/toMs` (numbers)
- `ComputeLast24hSummary`: Uses `activity.timestamp` directly (no more `Date.parse`)
- `IActivityRepository` + impls: `listByTimestampRange` uses numeric params
- New migration in `migrations.ts`

### Webapp
- `useNowBucket5Min`: Returns epoch ms number directly
- `page.tsx`: Numeric range params, `DateTime.fromMillis()` everywhere
- `activity-form-utils.ts`: `formatTime()`/`formatDate()` accept numbers
- `daily-summary.ts`: `toDateKey()` accepts `number | DateTime`
- All 3 edit pages updated
- All tests updated

### Mobile
- 6 files: `DateTime.fromISO(activity.timestamp)` → `DateTime.fromMillis(activity.timestamp)`
- Mutation write paths unchanged (still send ISO strings — backend converts)

## Why this fixes the root cause
- Numeric indexes sort correctly regardless of timezone — `1716163200000 < 1716249600000` always works
- No more mixed string formats in the DB after migration
- Consistent with Convex's own `_creationTime` convention

## Post-deploy step
```
npx convex run migrations:run '{"fn": "migrations:convertTimestampsToEpochMs"}'
```

## Test plan
- [x] `pnpm typecheck` — 3/3 packages clean
- [x] `pnpm test` — 264/264 passing (backend 20, webapp 235, mobile 9)
- [ ] Deploy to staging and run migration
- [ ] Verify activity feed loads correctly with converted timestamps
- [ ] Verify Load More pagination works across day boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)