### PR TITLE
Move timestamp conversion to repo layer, use epoch ms in domain

### DIFF
--- a/apps/mobile/app/diaper-change/create.tsx
+++ b/apps/mobile/app/diaper-change/create.tsx
@@ -18,9 +18,7 @@ export default function DiaperChangeCreatePage() {
             allowCreate = await requestAllowFutureDate();
           }
           if (allowCreate) {
-            const ts = formData.timestamp.toISO();
-            if (ts === null)
-              throw new Error('invalid timestamp: ' + formData.timestamp);
+            const ts = formData.timestamp.toMillis();
             await createActivity({
               deviceId,
               activity: {

--- a/apps/mobile/app/diaper-change/edit/[activityId].tsx
+++ b/apps/mobile/app/diaper-change/edit/[activityId].tsx
@@ -23,18 +23,18 @@ export default function EditDiaperChangePage() {
   const deleteActivity = useMutation(api.activities.deleteActivity);
   const diaperChangeFormRef = useRef<DiaperChangeFormRef>(null);
   useEffect(() => {
-    if (activity?.activity.type === ActivityType.DiaperChange) {
-      const diaperChange = activity.activity.diaperChange;
+    if (activity?.type === ActivityType.DiaperChange) {
+      const diaperChange = activity.diaperChange;
       if (!diaperChange) {
         alert('failed to load - diaper change data not found.');
         return;
       }
       diaperChangeFormRef.current?.load({
         type: diaperChangeFromLiteral(diaperChange.type),
-        timestamp: DateTime.fromISO(activity.activity.timestamp),
+        timestamp: DateTime.fromMillis(activity.timestamp),
       });
     }
-  }, [activity?.activity]);
+  }, [activity]);
   return (
     <EditActivityPageLayout
       title="Edit Feed"
@@ -47,9 +47,7 @@ export default function EditDiaperChangePage() {
         mode="edit"
         ref={diaperChangeFormRef}
         onSubmit={async function (formData): Promise<void> {
-          const ts = formData.timestamp.toISO();
-          if (ts === null)
-            throw new Error('invalid timestamp: ' + formData.timestamp);
+          const ts = formData.timestamp.toMillis();
           await updateActivity({
             deviceId,
             activityId,

--- a/apps/mobile/app/feed/create.tsx
+++ b/apps/mobile/app/feed/create.tsx
@@ -20,9 +20,7 @@ export default function CreateFeedPage() {
             allowCreate = await requestAllowFutureDate(); //update creation based on user permission
           }
           if (allowCreate) {
-            const ts = formData.timestamp.toISO();
-            if (ts === null)
-              throw new Error('invalid timestamp: ' + formData.timestamp);
+            const ts = formData.timestamp.toMillis();
             switch (formData.type) {
               case FeedType.Water:
               case FeedType.Expressed:

--- a/apps/mobile/app/feed/edit/[activityId].tsx
+++ b/apps/mobile/app/feed/edit/[activityId].tsx
@@ -23,15 +23,15 @@ export default function EditFeedPage() {
   const deleteActivity = useMutation(api.activities.deleteActivity);
   const feedFormRef = useRef<FeedFormRef>(null);
   useEffect(() => {
-    if (activity?.activity.type === ActivityType.Feed) {
-      const feed = activity.activity.feed;
+    if (activity?.type === ActivityType.Feed) {
+      const feed = activity.feed;
       switch (feed.type) {
         case 'water':
         case 'expressed':
         case 'formula': {
           feedFormRef.current?.load({
             type: feed.type as FeedType.Expressed | FeedType.Formula,
-            timestamp: DateTime.fromISO(activity.activity.timestamp),
+            timestamp: DateTime.fromMillis(activity.timestamp),
             volume: feed.volume.ml,
           });
           break;
@@ -39,7 +39,7 @@ export default function EditFeedPage() {
         case 'latch': {
           feedFormRef.current?.load({
             type: feed.type as FeedType.Latch,
-            timestamp: DateTime.fromISO(activity.activity.timestamp),
+            timestamp: DateTime.fromMillis(activity.timestamp),
             duration: {
               left: {
                 seconds: feed.duration.left?.seconds || 0,
@@ -54,7 +54,7 @@ export default function EditFeedPage() {
         case 'solids': {
           feedFormRef.current?.load({
             type: feed.type as FeedType.Solids,
-            timestamp: DateTime.fromISO(activity.activity.timestamp),
+            timestamp: DateTime.fromMillis(activity.timestamp),
             description: feed.description,
           });
           break;
@@ -66,7 +66,7 @@ export default function EditFeedPage() {
         }
       }
     }
-  }, [activity?.activity]);
+  }, [activity]);
   return (
     <Page title="Edit Feed">
       <View className=" items-end mr-2">
@@ -84,9 +84,7 @@ export default function EditFeedPage() {
         mode="edit"
         ref={feedFormRef}
         onSubmit={async function (formData): Promise<void> {
-          const ts = formData.timestamp.toISO();
-          if (ts === null)
-            throw new Error('invalid timestamp: ' + formData.timestamp);
+          const ts = formData.timestamp.toMillis();
           switch (formData.type) {
             case FeedType.Water:
             case FeedType.Expressed:

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -25,9 +25,9 @@ function AppIndexPage() {
   const curDate = useCurrentDateTime();
   const lastFeedTimestamp = activities?.find(
     (v) =>
-      v.activity.type === ActivityType.Feed &&
-      DateTime.fromISO(v.activity.timestamp).toMillis() <= curDate.toMillis()
-  )?.activity?.timestamp;
+      v.type === ActivityType.Feed &&
+      v.timestamp <= curDate.toMillis()
+  )?.timestamp;
   const isLoading = activities == undefined;
   //get feed stats
   const feedStats = useMemo<{
@@ -51,18 +51,18 @@ function AppIndexPage() {
     }[] = [];
     for (const f of activities) {
       if (
-        f.activity.type === ActivityType.Feed &&
-        f.activity.feed.type !== FeedType.Latch &&
-        f.activity.feed.type !== FeedType.Solids &&
-        DateTime.fromISO(f.activity.timestamp).toMillis() >
+        f.type === ActivityType.Feed &&
+        f.feed.type !== FeedType.Latch &&
+        f.feed.type !== FeedType.Solids &&
+        f.timestamp >
           last24HrRange.from.toMillis() &&
-        DateTime.fromISO(f.activity.timestamp).toMillis() <=
+        f.timestamp <=
           last24HrRange.to.toMillis()
       ) {
         last24HourFeedsWithVol.push({
           activity: {
-            dateTime: DateTime.fromISO(f.activity.timestamp),
-            feed: { volume: { ml: f.activity.feed.volume.ml } },
+            dateTime: DateTime.fromMillis(f.timestamp),
+            feed: { volume: { ml: f.feed.volume.ml } },
           },
         });
       }
@@ -85,7 +85,7 @@ function AppIndexPage() {
     //compute stats
     const last24HrFeedStats = last24HourFeedsWithVol.reduce(
       (state, f) => {
-        state.totalVol.ml += f.activity.feed.volume.ml;
+        state.totalVol.ml += f.feed.volume.ml;
         return state;
       },
       {
@@ -110,7 +110,7 @@ function AppIndexPage() {
     if (!lastFeedTimestamp) return undefined;
     return timeAgo({
       curDateTime: curDate,
-      dateTime: DateTime.fromISO(lastFeedTimestamp),
+      dateTime: DateTime.fromMillis(lastFeedTimestamp),
     }).toString();
   }, [curDate, lastFeedTimestamp]);
   return (
@@ -127,7 +127,7 @@ function AppIndexPage() {
         ) : null}
         <ActivityList
           onActivityPress={(a) => {
-            switch (a.activity.activity.type) {
+            switch (a.activity.type) {
               case ActivityType.Feed: {
                 router.push(`/feed/edit/${a.activity._id}`);
                 break;

--- a/apps/mobile/app/medical/create.tsx
+++ b/apps/mobile/app/medical/create.tsx
@@ -14,13 +14,11 @@ export default function CreateMedicalPage() {
       <MedicalActivityForm
         mode="create"
         onSubmit={async (val) => {
-          const ts = val.timestamp.toISO();
+          const ts = val.timestamp.toMillis();
           let allowCreate = true;
           if (val.timestamp.toMillis() > Date.now()) {
             allowCreate = await requestAllowFutureDate();
           }
-          if (ts === null)
-            throw new Error('invalid timestamp: ' + val.timestamp);
           if (allowCreate) {
             switch (val.type) {
               case 'temperature': {

--- a/apps/mobile/app/medical/edit/[activityId].tsx
+++ b/apps/mobile/app/medical/edit/[activityId].tsx
@@ -21,25 +21,25 @@ export default function EditMedicalPage() {
   const medicalFormRef = useRef<MedicalActivityFormRef>(null);
 
   useEffect(() => {
-    if (activity?.activity.type === 'medical') {
-      const medicalActivity = activity.activity.medical;
+    if (activity?.type === 'medical') {
+      const medicalActivity = activity.medical;
       if (medicalActivity.type === 'temperature') {
         medicalFormRef.current?.load({
           type: 'temperature',
-          timestamp: DateTime.fromISO(activity.activity.timestamp),
+          timestamp: DateTime.fromMillis(activity.timestamp),
           temperature: medicalActivity.temperature.value,
         });
       } else if (medicalActivity.type === 'medicine') {
         medicalFormRef.current?.load({
           type: 'medicine',
-          timestamp: DateTime.fromISO(activity.activity.timestamp),
+          timestamp: DateTime.fromMillis(activity.timestamp),
           name: medicalActivity.medicine.name,
           unit: medicalActivity.medicine.unit,
           value: medicalActivity.medicine.value,
         });
       }
     }
-  }, [activity?.activity]);
+  }, [activity]);
 
   return (
     <Page title="Edit Medical">
@@ -58,9 +58,7 @@ export default function EditMedicalPage() {
         mode="edit"
         ref={medicalFormRef}
         onSubmit={async (val) => {
-          const ts = val.timestamp.toISO();
-          if (ts === null)
-            throw new Error('invalid timestamp: ' + val.timestamp);
+          const ts = val.timestamp.toMillis();
           switch (val.type) {
             case 'temperature': {
               await updateActivity({

--- a/apps/mobile/src/components/molecules/ActivityList/ActivityListViewModel.tsx
+++ b/apps/mobile/src/components/molecules/ActivityList/ActivityListViewModel.tsx
@@ -31,8 +31,8 @@ export function viewModelFromActivities(
   return list.reduce(
     (state, activity) => {
       //insert sections
-      const activityDate = DateTime.fromISO(
-        activity.activity.timestamp
+      const activityDate = DateTime.fromMillis(
+        activity.timestamp
       ).toFormat('dd MMM yyyy');
       if (state.lastDate != activityDate) {
         state.lastDate = activityDate;

--- a/apps/mobile/src/components/molecules/ActivityList/index.tsx
+++ b/apps/mobile/src/components/molecules/ActivityList/index.tsx
@@ -56,12 +56,12 @@ function ActivityItem(props: {
   onPress: (e: { activity: Activity }) => void;
 }) {
   const activity = props.activity;
-  const activityTimestamp = DateTime.fromISO(activity.activity.timestamp);
+  const activityTimestamp = DateTime.fromMillis(activity.timestamp);
   let icon = <></>;
-  switch (activity.activity.type) {
+  switch (activity.type) {
     case ActivityType.Feed: {
       icon = <Text>🍼</Text>;
-      if (activity.activity.feed.type === FeedType.Water) {
+      if (activity.feed.type === FeedType.Water) {
         icon = <Text>💧</Text>;
       }
       break;
@@ -72,7 +72,7 @@ function ActivityItem(props: {
     }
     case ActivityType.Medical: {
       icon = <Text>💊</Text>;
-      if (activity.activity.medical.type === 'temperature') {
+      if (activity.medical.type === 'temperature') {
         icon = <Text>🌡️</Text>;
       }
       break;
@@ -85,9 +85,9 @@ function ActivityItem(props: {
   const { mainContent, subContent } = useMemo(() => {
     let mainContent = '';
     let subContent = '';
-    switch (activity.activity.type) {
+    switch (activity.type) {
       case ActivityType.Feed: {
-        const feed = activity.activity.feed;
+        const feed = activity.feed;
         mainContent = `${toPascalCase(feed.type)}`;
         switch (feed.type) {
           case FeedType.Latch: {
@@ -117,12 +117,12 @@ function ActivityItem(props: {
         break;
       }
       case ActivityType.DiaperChange: {
-        const diaperChange = activity.activity.diaperChange;
+        const diaperChange = activity.diaperChange;
         mainContent = `${toPascalCase(diaperChange.type)}`;
         break;
       }
       case ActivityType.Medical: {
-        const medical = activity.activity.medical;
+        const medical = activity.medical;
         switch (medical.type) {
           case 'temperature': {
             mainContent = `Temperature`;
@@ -139,7 +139,7 @@ function ActivityItem(props: {
       }
     }
     return { mainContent, subContent };
-  }, [activity.activity]);
+  }, [activity]);
   return (
     <TouchableOpacity
       onPress={() => props.onPress({ activity: props.activity })}

--- a/apps/webapp/src/app/app/diaper-change/create/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/diaper-change/create/page.ui.spec.tsx
@@ -160,7 +160,7 @@ describe('Diaper change create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'diaper_change',
             diaperChange: { type: 'wet' },
           },
@@ -178,7 +178,7 @@ describe('Diaper change create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'diaper_change',
             diaperChange: { type: 'dirty' },
           },
@@ -196,7 +196,7 @@ describe('Diaper change create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'diaper_change',
             diaperChange: { type: 'mixed' },
           },

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
@@ -71,7 +71,7 @@ export default function DiaperEditPage() {
 
     const existingRemarks = dc?.remarks as string | undefined;
     setDiaperType((existingType as DiaperType) || 'wet');
-    setDatetime(ts ? toLocalDatetimeString(ts) : '');
+    setDatetime(ts ? toLocalDatetimeString(ts as string | number) : '');
     setRemarks(existingRemarks || '');
     setInitialized(true);
   }, [activity, initialized]);

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
@@ -67,7 +67,7 @@ export default function DiaperEditPage() {
 
     const dc = activity.diaperChange as Record<string, unknown> | undefined;
     const existingType = dc?.type as string;
-    const ts = activity.timestamp as string;
+    const ts = activity.timestamp;
 
     const existingRemarks = dc?.remarks as string | undefined;
     setDiaperType((existingType as DiaperType) || 'wet');

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.ui.spec.tsx
@@ -26,7 +26,7 @@ const EXISTING_DIRTY: Record<string, unknown> = {
   data: {
     _id: 'act-diaper-1',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T10:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T10:00:00.000Z'),
     type: 'diaper_change',
     diaperChange: { type: 'dirty' },
   },
@@ -187,7 +187,7 @@ describe('Diaper change edit page', () => {
         expect(mockMutate).toHaveBeenCalledWith({
           activityId: 'act-diaper-1',
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'diaper_change',
             diaperChange: { type: 'mixed' },
           },

--- a/apps/webapp/src/app/app/feed/create/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/feed/create/page.ui.spec.tsx
@@ -241,7 +241,7 @@ describe('Feed create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'feed',
             feed: {
               type: 'latch',
@@ -268,7 +268,7 @@ describe('Feed create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'feed',
             feed: {
               type: 'expressed',
@@ -292,7 +292,7 @@ describe('Feed create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'feed',
             feed: {
               type: 'solids',

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
@@ -85,7 +85,7 @@ export default function FeedEditPage() {
 
     const feed = activity.feed as Record<string, unknown> | undefined;
     const feedSubType = feed?.type as string;
-    const ts = activity.timestamp as string;
+    const ts = activity.timestamp;
 
     setFeedType((feedSubType as FeedType) || 'latch');
     setDatetime(ts ? toLocalDatetimeString(ts) : '');

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
@@ -88,7 +88,7 @@ export default function FeedEditPage() {
     const ts = activity.timestamp;
 
     setFeedType((feedSubType as FeedType) || 'latch');
-    setDatetime(ts ? toLocalDatetimeString(ts) : '');
+    setDatetime(ts ? toLocalDatetimeString(ts as string | number) : '');
 
     if (feedSubType === 'latch') {
       const duration = feed?.duration as Record<string, { seconds: number }> | undefined;

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.ui.spec.tsx
@@ -109,7 +109,7 @@ function makeLatchQueryResult() {
     data: {
       _id: 'act-test-1',
       _creationTime: Date.now(),
-      timestamp: '2025-01-15T14:30:00.000Z',
+      timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
       type: 'feed',
       feed: {
         type: 'latch',
@@ -129,7 +129,7 @@ function makeBottleQueryResult() {
     data: {
       _id: 'act-test-1',
       _creationTime: Date.now(),
-      timestamp: '2025-01-15T14:30:00.000Z',
+      timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
       type: 'feed',
       feed: {
         type: 'expressed',
@@ -146,7 +146,7 @@ function makeSolidsQueryResult() {
     data: {
       _id: 'act-test-1',
       _creationTime: Date.now(),
-      timestamp: '2025-01-15T14:30:00.000Z',
+      timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
       type: 'feed',
       feed: {
         type: 'solids',
@@ -320,7 +320,7 @@ describe('Feed edit page', () => {
         expect(mockMutate).toHaveBeenCalledWith({
           activityId: 'act-test-1',
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'feed',
             feed: {
               type: 'latch',

--- a/apps/webapp/src/app/app/medical/create/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/medical/create/page.ui.spec.tsx
@@ -184,7 +184,7 @@ describe('Medical create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'medical',
             medical: {
               type: 'temperature',
@@ -221,7 +221,7 @@ describe('Medical create page', () => {
       await waitFor(() => {
         expect(mockCreateActivity).toHaveBeenCalledWith({
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'medical',
             medical: {
               type: 'medicine',

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
@@ -75,7 +75,7 @@ export default function MedicalEditPage() {
 
     const med = activity.medical as Record<string, unknown> | undefined;
     const existingType = med?.type as string;
-    const ts = activity.timestamp as string;
+    const ts = activity.timestamp;
 
     setMedicalType((existingType as MedicalType) || 'temperature');
     setDatetime(ts ? toLocalDatetimeString(ts) : '');

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
@@ -78,7 +78,7 @@ export default function MedicalEditPage() {
     const ts = activity.timestamp;
 
     setMedicalType((existingType as MedicalType) || 'temperature');
-    setDatetime(ts ? toLocalDatetimeString(ts) : '');
+    setDatetime(ts ? toLocalDatetimeString(ts as string | number) : '');
 
     if (existingType === 'temperature') {
       const temp = med?.temperature as { value: number } | undefined;

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.ui.spec.tsx
@@ -26,7 +26,7 @@ const EXISTING_TEMPERATURE: Record<string, unknown> = {
   data: {
     _id: 'act-med-1',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T10:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T10:00:00.000Z'),
     type: 'medical',
     medical: { type: 'temperature', temperature: { value: 37.5 } },
   },
@@ -37,7 +37,7 @@ const EXISTING_MEDICINE: Record<string, unknown> = {
   data: {
     _id: 'act-med-2',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T10:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T10:00:00.000Z'),
     type: 'medical',
     medical: { type: 'medicine', medicine: { name: 'Paracetamol', value: 5, unit: 'ml' } },
   },
@@ -233,7 +233,7 @@ describe('Medical edit page', () => {
         expect(mockMutate).toHaveBeenCalledWith({
           activityId: 'act-med-1',
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'medical',
             medical: {
               type: 'temperature',
@@ -262,7 +262,7 @@ describe('Medical edit page', () => {
         expect(mockMutate).toHaveBeenCalledWith({
           activityId: 'act-med-1',
           activity: {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             type: 'medical',
             medical: {
               type: 'medicine',

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -181,27 +181,20 @@ export default function AppHomePage() {
 
   const [daysBack, setDaysBack] = useState(2);
 
-  const nowIso = useNowBucket5Min();
-  const nowMs = DateTime.fromISO(nowIso).toMillis();
+  const nowMs = useNowBucket5Min();
 
-  const fromIso = useMemo(() => {
+  const fromMs = useMemo(() => {
     // Load from the requested number of days back, but always at least from yesterday midnight.
     // The last-24h summary needs activities from (now - 24h), which always falls on yesterday,
     // so we must never load less than yesterday's data regardless of daysBack.
-    //
-    // IMPORTANT: .toUTC() is required because the DB stores timestamps as ISO 8601 UTC strings
-    // (suffixed with Z) — the CreateActivity/UpdateActivity use cases normalise to UTC.
-    // Without .toUTC(), the output is a local-offset string (e.g. +08:00) that breaks the
-    // Convex string-index comparison against UTC timestamps, silently dropping activities
-    // from the first 8 hours of the day for GMT+8 users (the timezone bug).
     const requestedFrom = DateTime.now().startOf('day').minus({ days: daysBack - 1 });
     const minFrom = DateTime.now().startOf('day').minus({ days: 1 }); // yesterday midnight
-    return (requestedFrom < minFrom ? requestedFrom : minFrom).toUTC().toISO()!;
+    return (requestedFrom < minFrom ? requestedFrom : minFrom).toMillis();
   }, [daysBack]);
 
   const rangeResult = useSessionQuery(
     api.web.babyTracker.activities.getActivitiesByDateRange,
-    { fromIso, toIso: nowIso }
+    { fromMs, toMs: nowMs }
   );
 
   // Stale-while-revalidate: keep the last confirmed results so "Load More"

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -188,9 +188,15 @@ export default function AppHomePage() {
     // Load from the requested number of days back, but always at least from yesterday midnight.
     // The last-24h summary needs activities from (now - 24h), which always falls on yesterday,
     // so we must never load less than yesterday's data regardless of daysBack.
+    //
+    // IMPORTANT: .toUTC() is required because the DB stores timestamps as ISO 8601 UTC strings
+    // (suffixed with Z) — the CreateActivity/UpdateActivity use cases normalise to UTC.
+    // Without .toUTC(), the output is a local-offset string (e.g. +08:00) that breaks the
+    // Convex string-index comparison against UTC timestamps, silently dropping activities
+    // from the first 8 hours of the day for GMT+8 users (the timezone bug).
     const requestedFrom = DateTime.now().startOf('day').minus({ days: daysBack - 1 });
     const minFrom = DateTime.now().startOf('day').minus({ days: 1 }); // yesterday midnight
-    return (requestedFrom < minFrom ? requestedFrom : minFrom).toISO()!;
+    return (requestedFrom < minFrom ? requestedFrom : minFrom).toUTC().toISO()!;
   }, [daysBack]);
 
   const rangeResult = useSessionQuery(

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -107,8 +107,8 @@ const ACTIVITY_ICON_MAP: Record<string, React.ComponentType<{ className?: string
 export type TimeOfDay = 'midnight' | 'morning' | 'afternoon' | 'night';
 
 /** Classify a timestamp into a time-of-day bucket based on local hour. */
-function getTimeOfDay(ts: string): TimeOfDay {
-  const hour = DateTime.fromISO(ts).toLocal().hour;
+function getTimeOfDay(ts: number): TimeOfDay {
+  const hour = DateTime.fromMillis(ts).toLocal().hour;
   if (hour >= 6 && hour < 12) return 'morning';
   if (hour >= 12 && hour < 18) return 'afternoon';
   if (hour >= 18) return 'night';
@@ -242,9 +242,7 @@ export default function AppHomePage() {
 
   const groupedByDate = useMemo(() => {
     const sorted = [...results].sort((a, b) => {
-      const tsA = DateTime.fromISO(a.timestamp).toMillis();
-      const tsB = DateTime.fromISO(b.timestamp).toMillis();
-      return tsB - tsA;
+      return b.timestamp - a.timestamp;
     });
 
     const dateGroups: {
@@ -253,7 +251,7 @@ export default function AppHomePage() {
     }[] = [];
 
     for (const activity of sorted) {
-      const ts: string = activity.timestamp;
+      const ts = activity.timestamp;
       const dateKey = toDateKey(ts);
       const period = getTimeOfDay(ts);
 

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -85,7 +85,7 @@ function makeLatchActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-1',
     _creationTime: Date.now(),
-    timestamp: '2025-01-15T14:30:00.000Z',
+    timestamp: Date.parse('2025-01-15T14:30:00.000Z'),
     type: 'feed',
     feed: {
       type: 'latch',
@@ -100,7 +100,7 @@ function makeBottleActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-2',
     _creationTime: Date.now() - 1000,
-    timestamp: '2025-01-15T12:00:00.000Z',
+    timestamp: Date.parse('2025-01-15T12:00:00.000Z'),
     type: 'feed',
     feed: {
       type: 'expressed',
@@ -115,7 +115,7 @@ function makeSolidsActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-3',
     _creationTime: Date.now() - 2000,
-    timestamp: '2025-01-14T18:00:00.000Z',
+    timestamp: Date.parse('2025-01-14T18:00:00.000Z'),
     type: 'feed',
     feed: {
       type: 'solids',
@@ -130,7 +130,7 @@ function makeDiaperActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-4',
     _creationTime: Date.now() - 3000,
-    timestamp: '2025-01-14T16:30:00.000Z',
+    timestamp: Date.parse('2025-01-14T16:30:00.000Z'),
     type: 'diaper_change',
     diaperChange: {
       type: 'wet',
@@ -144,7 +144,7 @@ function makeTemperatureActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-5',
     _creationTime: Date.now() - 4000,
-    timestamp: '2025-01-14T09:00:00.000Z',
+    timestamp: Date.parse('2025-01-14T09:00:00.000Z'),
     type: 'medical',
     medical: {
       type: 'temperature',
@@ -159,7 +159,7 @@ function makeMedicineActivity(overrides?: Partial<Record<string, unknown>>) {
   return {
     _id: 'act-6',
     _creationTime: Date.now() - 5000,
-    timestamp: '2025-01-13T20:00:00.000Z',
+    timestamp: Date.parse('2025-01-13T20:00:00.000Z'),
     type: 'medical',
     medical: {
       type: 'medicine',
@@ -234,7 +234,7 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: Date.now() - 1000,
-          timestamp: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 1 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -316,10 +316,10 @@ describe('App home page', () => {
       // Jan 15 08:00 Z → SGT Jan 15 16:00 (afternoon) — local date = Jan 15.
       // Jan 15 12:00 Z → SGT Jan 15 20:00 (night) — local date = Jan 15.
       mockRangeResults = [
-        makeLatchActivity({ timestamp: '2025-01-14T15:59:59.000Z' }),
-        makeSolidsActivity({ timestamp: '2025-01-14T16:00:00.000Z' }),
-        makeBottleActivity({ timestamp: '2025-01-15T08:00:00.000Z' }),
-        makeDiaperActivity({ timestamp: '2025-01-15T12:00:00.000Z' }),
+        makeLatchActivity({ timestamp: Date.parse('2025-01-14T15:59:59.000Z') }),
+        makeSolidsActivity({ timestamp: Date.parse('2025-01-14T16:00:00.000Z') }),
+        makeBottleActivity({ timestamp: Date.parse('2025-01-15T08:00:00.000Z') }),
+        makeDiaperActivity({ timestamp: Date.parse('2025-01-15T12:00:00.000Z') }),
       ];
 
       render(<AppHomePage />);
@@ -523,7 +523,7 @@ describe('App home page', () => {
         {
           _id: 'act-yesterday',
           _creationTime: Date.now() - 86400000,
-          timestamp: '2025-05-18T10:00:00.000Z',
+          timestamp: Date.parse('2025-05-18T10:00:00.000Z'),
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -548,7 +548,7 @@ describe('App home page', () => {
         {
           _id: 'act-today',
           _creationTime: Date.now(),
-          timestamp: '2025-05-19T08:00:00.000Z',
+          timestamp: Date.parse('2025-05-19T08:00:00.000Z'),
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -569,21 +569,21 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 60 } },
         },
         {
           _id: 'b2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 90 } },
         },
         {
           _id: 'b3',
           _creationTime: now - 3000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'feed',
           feed: { type: 'formula', volume: { ml: 120 } },
         },
@@ -607,14 +607,14 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 60 } },
         },
         {
           _id: 'b2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 90 } },
         },
@@ -636,14 +636,14 @@ describe('App home page', () => {
         {
           _id: 'l1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'latch', duration: { left: { seconds: 600 }, right: { seconds: 300 } } },
         },
         {
           _id: 'l2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'feed',
           feed: { type: 'latch', duration: { left: { seconds: 900 }, right: { seconds: 450 } } },
         },
@@ -665,21 +665,21 @@ describe('App home page', () => {
         {
           _id: 's1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'solids', description: 'Banana' },
         },
         {
           _id: 's2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'feed',
           feed: { type: 'solids', description: 'banana' },
         },
         {
           _id: 's3',
           _creationTime: now - 3000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'feed',
           feed: { type: 'solids', description: 'Rice' },
         },
@@ -701,21 +701,21 @@ describe('App home page', () => {
         {
           _id: 'd1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
         {
           _id: 'd2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
         {
           _id: 'd3',
           _creationTime: now - 3000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'mixed' },
         },
@@ -741,7 +741,7 @@ describe('App home page', () => {
         {
           _id: 'd1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
@@ -762,14 +762,14 @@ describe('App home page', () => {
         {
           _id: 'm1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 3 * hour).toISOString(),
+          timestamp: now - 3 * hour,
           type: 'medical',
           medical: { type: 'temperature', temperature: { value: 37.8 } },
         },
         {
           _id: 'm2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 5 * hour).toISOString(),
+          timestamp: now - 5 * hour,
           type: 'medical',
           medical: { type: 'temperature', temperature: { value: 37.0 } },
         },
@@ -792,14 +792,14 @@ describe('App home page', () => {
         {
           _id: 'med1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'ml', value: 5 } },
         },
         {
           _id: 'med2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'ml', value: 5 } },
         },
@@ -821,14 +821,14 @@ describe('App home page', () => {
         {
           _id: 'med1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'ml', value: 5 } },
         },
         {
           _id: 'med2',
           _creationTime: now - 2000,
-          timestamp: new Date(now - 2 * hour).toISOString(),
+          timestamp: now - 2 * hour,
           type: 'medical',
           medical: { type: 'medicine', medicine: { name: 'Paracetamol', unit: 'g', value: 0.5 } },
         },
@@ -850,7 +850,7 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: now - 1000,
-          timestamp: new Date(now - 1 * hour).toISOString(),
+          timestamp: now - 1 * hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -881,7 +881,7 @@ describe('App home page', () => {
         {
           _id: 'b1',
           _creationTime: Date.now() - 1000,
-          timestamp: new Date(Date.now() - 1 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 1 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -904,7 +904,7 @@ describe('App home page', () => {
         {
           _id: 'd-yesterday',
           _creationTime: now - 25 * hour,
-          timestamp: new Date(now - 25 * hour).toISOString(), // 25h ago = yesterday
+          timestamp: now - 25 * hour, // 25h ago = yesterday
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
@@ -912,7 +912,7 @@ describe('App home page', () => {
         {
           _id: 'b-today',
           _creationTime: now - hour,
-          timestamp: new Date(now - hour).toISOString(),
+          timestamp: now - hour,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 120 } },
         },
@@ -942,7 +942,7 @@ describe('App home page', () => {
         {
           _id: 'd-yesterday',
           _creationTime: Date.now() - 20 * 3600 * 1000,
-          timestamp: '2025-05-18T14:00:00.000Z',
+          timestamp: Date.parse('2025-05-18T14:00:00.000Z'),
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },
@@ -968,7 +968,7 @@ describe('App home page', () => {
         {
           _id: 't-yesterday',
           _creationTime: Date.now() - 20 * 3600 * 1000,
-          timestamp: '2025-05-18T14:00:00.000Z',
+          timestamp: Date.parse('2025-05-18T14:00:00.000Z'),
           type: 'medical',
           medical: { type: 'temperature', temperature: { value: 37.5 } },
         },
@@ -1058,7 +1058,7 @@ describe('App home page', () => {
         {
           _id: 'feed-20h-ago',
           _creationTime: Date.now() - 20 * 3600 * 1000,
-          timestamp: new Date(Date.now() - 20 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 20 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 150 } },
         },
@@ -1076,7 +1076,7 @@ describe('App home page', () => {
         {
           _id: 'feed-25h-ago',
           _creationTime: Date.now() - 25 * 3600 * 1000,
-          timestamp: new Date(Date.now() - 25 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 25 * 3600 * 1000,
           type: 'feed',
           feed: { type: 'expressed', volume: { ml: 200 } },
         },
@@ -1096,7 +1096,7 @@ describe('App home page', () => {
         {
           _id: 'diaper-23h-ago',
           _creationTime: Date.now() - 23 * 3600 * 1000,
-          timestamp: new Date(Date.now() - 23 * 3600 * 1000).toISOString(),
+          timestamp: Date.now() - 23 * 3600 * 1000,
           type: 'diaper_change',
           diaperChange: { type: 'wet' },
         },

--- a/apps/webapp/src/lib/activity-form-utils.ts
+++ b/apps/webapp/src/lib/activity-form-utils.ts
@@ -25,6 +25,10 @@ export function toLocalDatetimeString(isoTs: string): string {
  * Converts a "datetime-local" input string (no timezone) to a timezone-aware ISO string.
  * Luxon treats a no-timezone ISO as local time, then .toISO() adds the offset.
  * Mirrors how mobile uses DateTime.fromJSDate(date).toISO() on submit.
+ *
+ * IMPORTANT: This produces a local-offset string (e.g. +08:00). The backend
+ * CreateActivity/UpdateActivity use cases normalise it to UTC before storing.
+ * The DB stores ISO 8601 UTC strings (suffixed with Z).
  */
 export function toTimestamp(datetimeLocalValue: string): string {
   return DateTime.fromISO(datetimeLocalValue).toISO()!;
@@ -50,12 +54,19 @@ export function formatDuration(totalSeconds: number): string {
   return `${minutes} min ${seconds} sec`;
 }
 
-/** Formats an ISO timestamp to a short time like "2:30 PM" using Luxon in local time. */
+/**
+ * Formats an ISO timestamp to a short time like "2:30 PM" using Luxon in local time.
+ * Input is expected to be an ISO 8601 UTC string (suffixed with Z), as stored in the DB.
+ * Luxon's fromISO handles the Z suffix and .toLocal() converts to the browser's timezone.
+ */
 export function formatTime(ts: string): string {
   return DateTime.fromISO(ts).toLocal().toFormat('h:mm a');
 }
 
-/** Formats a timestamp to a locale date string like "Jan 15, 2025" using Luxon in local time. */
+/**
+ * Formats a timestamp to a locale date string like "Jan 15, 2025" using Luxon in local time.
+ * Input is expected to be an ISO 8601 UTC string (suffixed with Z), as stored in the DB.
+ */
 export function formatDate(ts: string): string {
   return DateTime.fromISO(ts).toLocal().toFormat('MMM d, yyyy');
 }

--- a/apps/webapp/src/lib/activity-form-utils.ts
+++ b/apps/webapp/src/lib/activity-form-utils.ts
@@ -9,29 +9,25 @@ import { DateTime } from 'luxon';
 
 /** Returns current local datetime as "YYYY-MM-DDTHH:MM" for datetime-local inputs. */
 export function getDefaultDatetime(): string {
-  return toLocalDatetimeString(new Date().toISOString());
+  return toLocalDatetimeString(Date.now());
 }
 
 /**
- * Converts an ISO timestamp (UTC or offset) to a local "YYYY-MM-DDTHH:MM" string
+ * Converts an epoch-ms timestamp or ISO string to a local "YYYY-MM-DDTHH:MM" string
  * for use as the value of a datetime-local input.
- * Mirrors how the mobile pre-populates edit forms.
  */
-export function toLocalDatetimeString(isoTs: string): string {
-  return DateTime.fromISO(isoTs).toLocal().toFormat("yyyy-MM-dd'T'HH:mm");
+export function toLocalDatetimeString(ts: number | string): string {
+  const dt = typeof ts === 'number' ? DateTime.fromMillis(ts) : DateTime.fromISO(ts);
+  return dt.toLocal().toFormat("yyyy-MM-dd'T'HH:mm");
 }
 
 /**
- * Converts a "datetime-local" input string (no timezone) to a timezone-aware ISO string.
- * Luxon treats a no-timezone ISO as local time, then .toISO() adds the offset.
- * Mirrors how mobile uses DateTime.fromJSDate(date).toISO() on submit.
- *
- * IMPORTANT: This produces a local-offset string (e.g. +08:00). The backend
- * CreateActivity/UpdateActivity use cases normalise it to UTC before storing.
- * The DB stores ISO 8601 UTC strings (suffixed with Z).
+ * Converts a "datetime-local" input string (no timezone) to epoch milliseconds.
+ * Luxon treats a no-timezone ISO as local time, so the epoch ms correctly represents
+ * the chosen local datetime in UTC.
  */
-export function toTimestamp(datetimeLocalValue: string): string {
-  return DateTime.fromISO(datetimeLocalValue).toISO()!;
+export function toTimestamp(datetimeLocalValue: string): number {
+  return DateTime.fromISO(datetimeLocalValue).toMillis();
 }
 
 /** Converts minutes + seconds to total seconds. */
@@ -55,20 +51,19 @@ export function formatDuration(totalSeconds: number): string {
 }
 
 /**
- * Formats an ISO timestamp to a short time like "2:30 PM" using Luxon in local time.
- * Input is expected to be an ISO 8601 UTC string (suffixed with Z), as stored in the DB.
- * Luxon's fromISO handles the Z suffix and .toLocal() converts to the browser's timezone.
+ * Formats an epoch-ms or ISO timestamp to a short time like "2:30 PM" in local time.
  */
-export function formatTime(ts: string): string {
-  return DateTime.fromISO(ts).toLocal().toFormat('h:mm a');
+export function formatTime(ts: number | string): string {
+  const dt = typeof ts === 'number' ? DateTime.fromMillis(ts) : DateTime.fromISO(ts);
+  return dt.toLocal().toFormat('h:mm a');
 }
 
 /**
- * Formats a timestamp to a locale date string like "Jan 15, 2025" using Luxon in local time.
- * Input is expected to be an ISO 8601 UTC string (suffixed with Z), as stored in the DB.
+ * Formats an epoch-ms or ISO timestamp to a locale date string like "Jan 15, 2025" in local time.
  */
-export function formatDate(ts: string): string {
-  return DateTime.fromISO(ts).toLocal().toFormat('MMM d, yyyy');
+export function formatDate(ts: number | string): string {
+  const dt = typeof ts === 'number' ? DateTime.fromMillis(ts) : DateTime.fromISO(ts);
+  return dt.toLocal().toFormat('MMM d, yyyy');
 }
 
 /**

--- a/apps/webapp/src/lib/daily-summary.spec.ts
+++ b/apps/webapp/src/lib/daily-summary.spec.ts
@@ -137,9 +137,9 @@ describe('computeDailySummary', () => {
         lastWetAgoMs: expect.any(Number),
         lastDirtyAgoMs: expect.any(Number),
         lastMixedAgoMs: expect.any(Number),
-        lastWetAt: twoHoursAgo,
-        lastDirtyAt: eightHoursAgo,
-        lastMixedAt: sixHoursAgo,
+        lastWetAt: Date.parse(twoHoursAgo),
+        lastDirtyAt: Date.parse(eightHoursAgo),
+        lastMixedAt: Date.parse(sixHoursAgo),
       });
 
       const lastWetAgo = result.diapers!.lastWetAgoMs!;
@@ -177,7 +177,7 @@ describe('computeDailySummary', () => {
       expect(result.medical!.latestTemperature).toEqual({
         valueC: 37.5,
         agoMs: expect.any(Number),
-        at: nineAmJan15,
+        at: Date.parse(nineAmJan15),
       });
       expect(result.medical!.medicines).toHaveLength(2);
 
@@ -402,7 +402,7 @@ describe('computeDailySummariesByDay', () => {
     expect(result[0].dayStart.toISO()).toBe('2025-01-15T00:00:00.000Z');
   });
 
-  it('latestTemperature.at is an ISO string when day has non-medical activity', () => {
+  it('latestTemperature.at is an epoch ms number when day has non-medical activity', () => {
     vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
     const ref = DateTime.utc();
 
@@ -415,7 +415,7 @@ describe('computeDailySummariesByDay', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].summary.hasAny).toBe(true);
-    expect(result[0].summary.medical?.latestTemperature?.at).toBe('2025-01-15T10:00:00.000Z');
+    expect(result[0].summary.medical?.latestTemperature?.at).toBe(Date.parse('2025-01-15T10:00:00.000Z'));
   });
 });
 

--- a/apps/webapp/src/lib/daily-summary.spec.ts
+++ b/apps/webapp/src/lib/daily-summary.spec.ts
@@ -21,19 +21,19 @@ function referenceTime(iso: string, zone = 'local') {
 // ── Activity factories ───────────────────────────────────────────────────────
 
 function makeFeed(ts: string, subType: string, extras: Record<string, unknown> = {}) {
-  return { type: 'feed' as const, timestamp: ts, feed: { type: subType, ...extras } };
+  return { type: 'feed' as const, timestamp: Date.parse(ts), feed: { type: subType, ...extras } };
 }
 
 function makeDiaper(ts: string, diaperType: string) {
-  return { type: 'diaper_change' as const, timestamp: ts, diaperChange: { type: diaperType } };
+  return { type: 'diaper_change' as const, timestamp: Date.parse(ts), diaperChange: { type: diaperType } };
 }
 
 function makeTemp(ts: string, value: number) {
-  return { type: 'medical' as const, timestamp: ts, medical: { type: 'temperature' as const, temperature: { value } } };
+  return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'temperature' as const, temperature: { value } } };
 }
 
 function makeMedicine(ts: string, name: string, unit: string, value: number) {
-  return { type: 'medical' as const, timestamp: ts, medical: { type: 'medicine' as const, medicine: { name, unit, value } } };
+  return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'medicine' as const, medicine: { name, unit, value } } };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -256,8 +256,8 @@ describe('computeDailySummary', () => {
       const activities: unknown[] = [
         { type: 'feed' }, // completely malformed — missing timestamp, filtered out
         null,
-        { type: 'diaper_change', timestamp: 'invalid-ts' }, // unparseable timestamp
-        { type: 'feed', timestamp: '2025-01-15T08:00:00.000Z', feed: { type: 'water' } }, // valid timestamp, water feed = bottle total 0, count 1
+        { type: 'diaper_change', timestamp: NaN }, // unparseable timestamp (NaN)
+        { type: 'feed', timestamp: Date.parse('2025-01-15T08:00:00.000Z'), feed: { type: 'water' } }, // valid, water feed = bottle total 0, count 1
       ];
 
       const result = computeDailySummary(activities as readonly unknown[], { ...range, referenceTime: ref });

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -17,7 +17,8 @@ type MedicalSubType = 'temperature' | 'medicine';
 
 interface FeedActivity {
   type: 'feed';
-  timestamp: string;
+  /** Epoch milliseconds (UTC) — matches the domain type and API return value. */
+  timestamp: number;
   feed: {
     type: FeedSubType;
     duration?: { left?: { seconds?: number }; right?: { seconds?: number } };
@@ -28,13 +29,15 @@ interface FeedActivity {
 
 interface DiaperActivity {
   type: 'diaper_change';
-  timestamp: string;
+  /** Epoch milliseconds (UTC) — matches the domain type and API return value. */
+  timestamp: number;
   diaperChange: { type: DiaperSubType };
 }
 
 interface MedicalActivity {
   type: 'medical';
-  timestamp: string;
+  /** Epoch milliseconds (UTC) — matches the domain type and API return value. */
+  timestamp: number;
   medical: {
     type: MedicalSubType;
     temperature?: { value?: number };
@@ -47,16 +50,16 @@ export type Activity = FeedActivity | DiaperActivity | MedicalActivity;
 // ── Date-key helper (shared with callers) ─────────────────────────────────────
 
 /**
- * Formats a DateTime or ISO timestamp string as `YYYY-MM-DD` in the local zone.
+ * Formats a DateTime, epoch ms number, or ISO timestamp string as `YYYY-MM-DD` in the local zone.
  * Used to derive `dateKey` for grouping activities by day.
- *
- * Input timestamps are ISO 8601 UTC strings (suffixed with Z) as stored in the DB.
- * The CreateActivity/UpdateActivity use cases normalise to UTC before storing.
- * Luxon's DateTime.fromISO correctly handles the Z suffix and .toLocal() converts
- * to the browser's local timezone for display.
  */
-export function toDateKey(input: string | DateTime, zone: string = 'local'): string {
-  const dt = typeof input === 'string' ? DateTime.fromISO(input, { zone }) : input.setZone(zone);
+export function toDateKey(input: number | string | DateTime, zone: string = 'local'): string {
+  const dt =
+    typeof input === 'number'
+      ? DateTime.fromMillis(input, { zone })
+      : typeof input === 'string'
+        ? DateTime.fromISO(input, { zone })
+        : input.setZone(zone);
   return dt.toLocal().toFormat('yyyy-MM-dd');
 }
 
@@ -77,16 +80,16 @@ export interface DailySummary {
     lastWetAgoMs: number | null;
     lastDirtyAgoMs: number | null;
     lastMixedAgoMs: number | null;
-    lastWetAt: string | null;
-    lastDirtyAt: string | null;
-    lastMixedAt: string | null;
+    lastWetAt: number | null;
+    lastDirtyAt: number | null;
+    lastMixedAt: number | null;
   } | null;
   /**
    * Medical aggregation is computed but NOT rendered by DailySummaryCard
    * (intentional — re-enabling the UI is a render-only change).
    */
   medical: {
-    latestTemperature: { valueC: number; agoMs: number; at: string } | null;
+    latestTemperature: { valueC: number; agoMs: number; at: number } | null;
     medicines: Array<{
       name: string;
       unit: string;
@@ -131,15 +134,15 @@ export function computeDailySummary(
     const act = parseActivity(a);
     if (!act) continue;
     const ts = act.timestamp;
-    if (!ts) continue;
-    const dt = DateTime.fromISO(ts, { zone });
+    if (ts == null) continue;
+    const dt = DateTime.fromMillis(ts, { zone });
     if (!dt.isValid) continue;
     if (dt < dayStart || dt > dayEnd) continue;
     todaysActivities.push(act);
   }
 
   // Sort by timestamp ascending (needed for stable "last seen" tracking)
-  todaysActivities.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  todaysActivities.sort((a, b) => a.timestamp - b.timestamp);
 
   // Aggregate feed
   let bottleTotalMl = 0;
@@ -153,13 +156,13 @@ export function computeDailySummary(
   let wetCount = 0;
   let dirtyCount = 0;
   let mixedCount = 0;
-  let lastWetTs: string | null = null;
-  let lastDirtyTs: string | null = null;
-  let lastMixedTs: string | null = null;
+  let lastWetTs: number | null = null;
+  let lastDirtyTs: number | null = null;
+  let lastMixedTs: number | null = null;
 
   // Aggregate medical
   let latestTempValue: number | null = null;
-  let latestTempTs: string | null = null;
+  let latestTempTs: number | null = null;
   const medicineMap = new Map<
     string,
     { name: string; unit: string; totalValue: number; count: number; mixedUnits: boolean }
@@ -254,15 +257,9 @@ export function computeDailySummary(
           dirty: dirtyCount,
           mixed: mixedCount,
           total: wetCount + dirtyCount + mixedCount,
-          lastWetAgoMs: lastWetTs
-            ? referenceTime.toMillis() - DateTime.fromISO(lastWetTs, { zone }).toMillis()
-            : null,
-          lastDirtyAgoMs: lastDirtyTs
-            ? referenceTime.toMillis() - DateTime.fromISO(lastDirtyTs, { zone }).toMillis()
-            : null,
-          lastMixedAgoMs: lastMixedTs
-            ? referenceTime.toMillis() - DateTime.fromISO(lastMixedTs, { zone }).toMillis()
-            : null,
+          lastWetAgoMs: lastWetTs !== null ? referenceTime.toMillis() - lastWetTs : null,
+          lastDirtyAgoMs: lastDirtyTs !== null ? referenceTime.toMillis() - lastDirtyTs : null,
+          lastMixedAgoMs: lastMixedTs !== null ? referenceTime.toMillis() - lastMixedTs : null,
           lastWetAt: lastWetTs,
           lastDirtyAt: lastDirtyTs,
           lastMixedAt: lastMixedTs,
@@ -273,7 +270,7 @@ export function computeDailySummary(
     latestTempValue !== null && latestTempTs !== null
       ? {
           valueC: latestTempValue,
-          agoMs: referenceTime.toMillis() - DateTime.fromISO(latestTempTs, { zone }).toMillis(),
+          agoMs: referenceTime.toMillis() - latestTempTs,
           at: latestTempTs,
         }
       : null;
@@ -328,8 +325,8 @@ export function computeDailySummariesByDay(
   const dayMap = new Map<string, unknown[]>();
   for (const a of activities) {
     const act = parseActivity(a);
-    if (!act || !act.timestamp) continue;
-    const dt = DateTime.fromISO(act.timestamp, { zone });
+    if (!act || act.timestamp == null) continue;
+    const dt = DateTime.fromMillis(act.timestamp, { zone });
     if (!dt.isValid) continue;
     const key = toDateKey(dt);
     if (!dayMap.has(key)) dayMap.set(key, []);
@@ -390,7 +387,7 @@ export function computeLast24hSummary(
   let wet = 0, dirty = 0, mixed = 0;
 
   for (const activity of activities) {
-    const tsMs = Date.parse(activity.timestamp);
+    const tsMs = activity.timestamp;
     if (tsMs <= nowMs && tsMs > windowStartMs) {
       if (activity.type === 'feed') {
         if (tsMs > (lastFeedAtMs ?? 0)) lastFeedAtMs = tsMs;

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -49,6 +49,11 @@ export type Activity = FeedActivity | DiaperActivity | MedicalActivity;
 /**
  * Formats a DateTime or ISO timestamp string as `YYYY-MM-DD` in the local zone.
  * Used to derive `dateKey` for grouping activities by day.
+ *
+ * Input timestamps are ISO 8601 UTC strings (suffixed with Z) as stored in the DB.
+ * The CreateActivity/UpdateActivity use cases normalise to UTC before storing.
+ * Luxon's DateTime.fromISO correctly handles the Z suffix and .toLocal() converts
+ * to the browser's local timezone for display.
  */
 export function toDateKey(input: string | DateTime, zone: string = 'local'): string {
   const dt = typeof input === 'string' ? DateTime.fromISO(input, { zone }) : input.setZone(zone);

--- a/apps/webapp/src/lib/use-now-bucket.spec.ts
+++ b/apps/webapp/src/lib/use-now-bucket.spec.ts
@@ -31,9 +31,11 @@ describe('useNowBucket5Min', () => {
     vi.useRealTimers();
   });
 
-  it('returns ISO string with UTC zone', () => {
+  it('returns epoch ms number rounded up to next 5-min boundary', () => {
     vi.setSystemTime(new Date('2025-01-15T12:03:00.000Z'));
     const { result } = renderHook(() => useNowBucket5Min());
-    expect(result.current).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$/);
+    expect(typeof result.current).toBe('number');
+    expect(result.current % 300_000).toBe(0);
+    expect(result.current).toBeGreaterThan(new Date('2025-01-15T12:03:00.000Z').getTime());
   });
 });

--- a/apps/webapp/src/lib/use-now-bucket.ts
+++ b/apps/webapp/src/lib/use-now-bucket.ts
@@ -25,5 +25,8 @@ export function useNowBucket5Min(): string {
     return () => clearTimeout(timerId);
   }, []);
 
+  // Returns ISO 8601 UTC string (Z suffix) to match the DB storage format.
+  // The CreateActivity/UpdateActivity use cases normalise timestamps to UTC,
+  // so all query bounds must be in UTC for correct string-index comparison.
   return DateTime.fromMillis(bucket, { zone: 'utc' }).toISO()!;
 }

--- a/apps/webapp/src/lib/use-now-bucket.ts
+++ b/apps/webapp/src/lib/use-now-bucket.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { DateTime } from 'luxon';
 
 export function roundUpToNext5Min(ms: number): number {
   const boundary = Math.ceil(ms / 300_000) * 300_000;
@@ -7,7 +6,7 @@ export function roundUpToNext5Min(ms: number): number {
   return boundary;
 }
 
-export function useNowBucket5Min(): string {
+export function useNowBucket5Min(): number {
   const [bucket, setBucket] = useState<number>(() => roundUpToNext5Min(Date.now()));
 
   useEffect(() => {
@@ -25,8 +24,5 @@ export function useNowBucket5Min(): string {
     return () => clearTimeout(timerId);
   }, []);
 
-  // Returns ISO 8601 UTC string (Z suffix) to match the DB storage format.
-  // The CreateActivity/UpdateActivity use cases normalise timestamps to UTC,
-  // so all query bounds must be in UTC for correct string-index comparison.
-  return DateTime.fromMillis(bucket, { zone: 'utc' }).toISO()!;
+  return bucket;
 }

--- a/apps/webapp/src/modules/baby-tracker/DailySummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/DailySummaryCard.spec.tsx
@@ -83,7 +83,7 @@ describe('DailySummaryCard', () => {
           lastWetAgoMs: 3_600_000,
           lastDirtyAgoMs: null,
           lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T08:00:00.000Z',
+          lastWetAt: 1736928000000,
           lastDirtyAt: null,
           lastMixedAt: null,
         },
@@ -109,8 +109,8 @@ describe('DailySummaryCard', () => {
           lastWetAgoMs: 7_200_000,
           lastDirtyAgoMs: 5_400_000,
           lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T08:00:00.000Z',
-          lastDirtyAt: '2025-01-15T10:00:00.000Z',
+          lastWetAt: 1736928000000,
+          lastDirtyAt: 1736935200000,
           lastMixedAt: null,
         },
         medical: null,
@@ -133,8 +133,8 @@ describe('DailySummaryCard', () => {
           lastDirtyAgoMs: 10_800_000,
           lastMixedAgoMs: 5_400_000,
           lastWetAt: null,
-          lastDirtyAt: '2025-01-15T10:00:00.000Z',
-          lastMixedAt: '2025-01-15T08:00:00.000Z',
+          lastDirtyAt: 1736935200000,
+          lastMixedAt: 1736928000000,
         },
         medical: null,
       };
@@ -151,7 +151,7 @@ describe('DailySummaryCard', () => {
         diapers: {
           wet: 1, dirty: 0, mixed: 0, total: 1,
           lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T10:00:00.000Z', lastDirtyAt: null, lastMixedAt: null,
+          lastWetAt: 1736935200000, lastDirtyAt: null, lastMixedAt: null,
         },
         medical: null,
       };
@@ -166,7 +166,7 @@ describe('DailySummaryCard', () => {
         diapers: {
           wet: 1, dirty: 0, mixed: 0, total: 1,
           lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null,
-          lastWetAt: '2025-01-15T10:30:00.000Z', lastDirtyAt: null, lastMixedAt: null,
+          lastWetAt: 1736937000000, lastDirtyAt: null, lastMixedAt: null,
         },
         medical: null,
       };
@@ -180,7 +180,7 @@ describe('DailySummaryCard', () => {
       const summary: DailySummary = {
         hasAny: true,
         feed: { bottle: null, latch: null, solids: null },
-        diapers: { wet: 2, dirty: 0, mixed: 0, total: 2, lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null, lastWetAt: '2025-05-19T10:00:00.000Z', lastDirtyAt: null, lastMixedAt: null },
+        diapers: { wet: 2, dirty: 0, mixed: 0, total: 2, lastWetAgoMs: 3_600_000, lastDirtyAgoMs: null, lastMixedAgoMs: null, lastWetAt: 1747648800000, lastDirtyAt: null, lastMixedAt: null },
         medical: null,
       };
       render(<DailySummaryCard summary={summary} isToday={true} />);

--- a/services/backend/convex/activities.ts
+++ b/services/backend/convex/activities.ts
@@ -1,6 +1,5 @@
 import { mutation, query } from './_generated/server';
 import { v } from 'convex/values';
-import { Doc } from '../convex/_generated/dataModel';
 import { paginationOptsValidator } from 'convex/server';
 import { ConvexActivityRepository } from '../src/infra/ConvexActivityRepository';
 import {
@@ -11,9 +10,48 @@ import {
   getActivities as getActivitiesUsecase,
 } from '../src/domain/usecases/activity';
 
-// ── Public types (backward-compatible exports) ─────────────────
+// ── Public types ───────────────────────────────────────────────
 
-export type Activity = Doc<'activities'>;
+/**
+ * Runtime shape returned by the mobile endpoints.
+ * `getById` returns the inner activity (no `_id`).
+ * `getByTimestampDescPaginated` returns the inner activity with `_id`.
+ * Timestamps are epoch milliseconds.
+ */
+export type Activity = {
+  type: 'feed';
+  timestamp: number;
+  feed: {
+    type: 'latch';
+    duration: { left?: { seconds?: number }; right?: { seconds?: number } };
+  } | {
+    type: 'expressed' | 'formula' | 'water';
+    volume: { ml: number };
+  } | {
+    type: 'solids';
+    description: string;
+  };
+  _id?: string;
+} | {
+  type: 'diaper_change';
+  timestamp: number;
+  diaperChange: {
+    type: 'wet' | 'dirty' | 'mixed';
+  };
+  _id?: string;
+} | {
+  type: 'medical';
+  timestamp: number;
+  medical: {
+    type: 'temperature';
+    temperature: { value: number };
+  } | {
+    type: 'medicine';
+    medicine: { name: string; unit: string; value: number };
+  };
+  _id?: string;
+};
+
 export enum ActivityType {
   Feed = 'feed',
   DiaperChange = 'diaper_change',
@@ -28,7 +66,7 @@ export const create = mutation({
     activity: v.union(
       //feed activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('feed'),
         feed: v.union(
           v.object({
@@ -60,7 +98,7 @@ export const create = mutation({
       }),
       //diaper change activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('diaper_change'),
         diaperChange: v.object({
           type: v.union(
@@ -72,7 +110,7 @@ export const create = mutation({
       }),
       // medical activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('medical'),
         medical: v.union(
           v.object({
@@ -95,7 +133,7 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     const repo = new ConvexActivityRepository(ctx);
-    const activityId = await createActivityUsecase(repo, args.deviceId, args.activity as any);
+    const activityId = await createActivityUsecase(repo, args.deviceId, args.activity);
     return { activityId };
   },
 });
@@ -107,7 +145,7 @@ export const update = mutation({
     activity: v.union(
       //feed activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('feed'),
         feed: v.union(
           v.object({
@@ -139,7 +177,7 @@ export const update = mutation({
       }),
       //diaper change activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('diaper_change'),
         diaperChange: v.object({
           type: v.union(
@@ -151,7 +189,7 @@ export const update = mutation({
       }),
       // medical activity
       v.object({
-        timestamp: v.string(),
+        timestamp: v.number(),
         type: v.literal('medical'),
         medical: v.union(
           v.object({
@@ -174,7 +212,7 @@ export const update = mutation({
   },
   handler: async (ctx, args) => {
     const repo = new ConvexActivityRepository(ctx);
-    await updateActivityUsecase(repo, args.deviceId, args.activityId, args.activity as any);
+    await updateActivityUsecase(repo, args.deviceId, args.activityId, args.activity);
     // Maintain backward-compatible return: all activities
     const activities = await ctx.db.query('activities').collect();
     return activities;

--- a/services/backend/convex/migrations.ts
+++ b/services/backend/convex/migrations.ts
@@ -50,6 +50,12 @@ export const setUserAccessLevelDefault = migrations.define({
 /**
  * Migration: Fix webapp activity timestamps that were stored in UTC due to timezone bug.
  *
+ * NOTE on current UTC normalisation (as of the current codebase):
+ * The CreateActivity and UpdateActivity use cases now explicitly convert timestamps
+ * to UTC via ts.toUTC().toISO() before storing. This migration is a one-time fix for
+ * legacy data created before that normalisation was added. All new activities are
+ * stored in UTC format by the use case layer.
+ *
  * Old webapp used `new Date().toISOString().slice(0, 16)` for the datetime-local input default,
  * which returned UTC time. When saved, the browser re-interpreted this UTC string as local time,
  * resulting in timestamps shifted by the user's UTC offset (e.g., 8 hours early for UTC+8 users).

--- a/services/backend/convex/schema.ts
+++ b/services/backend/convex/schema.ts
@@ -12,6 +12,7 @@ export default defineSchema({
     activity: v.union(
       //feed activity
       v.object({
+        // ISO 8601 UTC string (suffixed with Z). Normalized by CreateActivity/UpdateActivity use cases.
         timestamp: v.string(),
         type: v.literal('feed'),
         feed: v.union(
@@ -44,6 +45,7 @@ export default defineSchema({
       }),
       //diaper change activity
       v.object({
+        // ISO 8601 UTC string (suffixed with Z). Normalized by CreateActivity/UpdateActivity use cases.
         timestamp: v.string(),
         type: v.literal('diaper_change'),
         diaperChange: v.object({
@@ -57,6 +59,7 @@ export default defineSchema({
       }),
       // medical activity
       v.object({
+        // ISO 8601 UTC string (suffixed with Z). Normalized by CreateActivity/UpdateActivity use cases.
         timestamp: v.string(),
         type: v.literal('medical'),
         medical: v.union(

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -7,8 +7,6 @@ import { v } from 'convex/values';
 import { paginationOptsValidator } from 'convex/server';
 import { SessionIdArg } from 'convex-helpers/server/sessions';
 import { mutation, query } from '../../_generated/server';
-import { ConvexError } from 'convex/values';
-import { DateTime } from 'luxon';
 import { ConvexWebActivityRepository } from '../../../src/infra/ConvexWebActivityRepository';
 import {
   createActivity as createActivityUseCase,
@@ -25,10 +23,8 @@ import { requireAuthAndFamily } from './helpers';
 const activityValidator = v.union(
   // feed activity
   v.object({
-    // ISO 8601 UTC string (suffixed with Z). The Create and Update use cases normalise
-    // whatever the client sends into UTC via ts.toUTC().toISO() before storing.
-    // Query args (fromIso/toIso) must also be in UTC for string-index comparison to work.
-    timestamp: v.string(),
+    // Epoch milliseconds (UTC). Converted to ISO 8601 UTC string by the repository layer.
+    timestamp: v.number(),
     type: v.literal('feed'),
     feed: v.union(
       v.object({
@@ -54,8 +50,8 @@ const activityValidator = v.union(
   }),
   // diaper change activity
   v.object({
-    // ISO 8601 UTC string (suffixed with Z). See feed comment for details.
-    timestamp: v.string(),
+    // Epoch milliseconds (UTC). Converted by the repository layer.
+    timestamp: v.number(),
     type: v.literal('diaper_change'),
     diaperChange: v.object({
       type: v.union(
@@ -68,8 +64,8 @@ const activityValidator = v.union(
   }),
   // medical activity
   v.object({
-    // ISO 8601 UTC string (suffixed with Z). See feed comment for details.
-    timestamp: v.string(),
+    // Epoch milliseconds (UTC). Converted by the repository layer.
+    timestamp: v.number(),
     type: v.literal('medical'),
     medical: v.union(
       v.object({
@@ -175,22 +171,18 @@ export const getByTimestampDescPaginated = query({
 
 /**
  * Get a summary of all feed and diaper activities from the last 24 hours.
- * The nowIso argument is rounded to the nearest 5-min bucket by the client
- * using useNowBucket5Min(), so Convex can memoize the result per bucket.
+ * The nowMs argument is epoch milliseconds (rounded to the nearest 5-min bucket
+ * by the client's useNowBucket5Min() for Convex memoization).
  */
 export const getLast24hSummary = query({
   args: {
     ...SessionIdArg,
-    nowIso: v.string(),
+    nowMs: v.number(),
   },
   handler: async (ctx, args) => {
     const { activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
     const repo = new ConvexWebActivityRepository(ctx, activityStreamId);
-    const nowMs = DateTime.fromISO(args.nowIso).toMillis();
-    if (!Number.isFinite(nowMs)) {
-      throw new ConvexError({ code: 'BAD_REQUEST', message: 'Invalid nowIso' });
-    }
-    return await getLast24hSummaryUseCase(repo, nowMs);
+    return await getLast24hSummaryUseCase(repo, args.nowMs);
   },
 });
 
@@ -199,29 +191,33 @@ export const getLast24hSummary = query({
  * Returns activities ordered by timestamp descending (newest first).
  * Used for day-based pagination on the home page.
  *
- * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z) so that
- * the Convex string-index comparison against the stored UTC timestamps is correct.
- * Passing local-offset strings (e.g. +08:00) causes incorrect filtering for users
- * with non-UTC timezones (see the app home page timezone bug fix).
+ * Both fromMs and toMs are epoch milliseconds. The handler converts them to ISO 8601
+ * UTC strings for the Convex string-index comparison against the stored UTC timestamps.
  */
 export const getActivitiesByDateRange = query({
   args: {
     ...SessionIdArg,
-    fromIso: v.string(),
-    toIso: v.string(),
+    fromMs: v.number(),
+    toMs: v.number(),
   },
   handler: async (ctx, args) => {
     const { activityStreamId } = await requireAuthAndFamily(ctx, args.sessionId);
+    const fromIso = new Date(args.fromMs).toISOString();
+    const toIso = new Date(args.toMs).toISOString();
     const docs = await ctx.db
       .query('activities')
       .withIndex('by_activityStreamId_by_timestamp', (q) =>
         q
           .eq('activityStreamId', activityStreamId)
-          .gte('activity.timestamp', args.fromIso)
-          .lte('activity.timestamp', args.toIso)
+          .gte('activity.timestamp', fromIso)
+          .lte('activity.timestamp', toIso)
       )
       .order('desc')
       .collect();
-    return docs.map((doc) => ({ ...doc.activity, _id: doc._id }));
+    return docs.map((doc) => ({
+      ...doc.activity,
+      _id: doc._id,
+      timestamp: Date.parse(doc.activity.timestamp),
+    }));
   },
 });

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -25,6 +25,9 @@ import { requireAuthAndFamily } from './helpers';
 const activityValidator = v.union(
   // feed activity
   v.object({
+    // ISO 8601 UTC string (suffixed with Z). The Create and Update use cases normalise
+    // whatever the client sends into UTC via ts.toUTC().toISO() before storing.
+    // Query args (fromIso/toIso) must also be in UTC for string-index comparison to work.
     timestamp: v.string(),
     type: v.literal('feed'),
     feed: v.union(
@@ -51,6 +54,7 @@ const activityValidator = v.union(
   }),
   // diaper change activity
   v.object({
+    // ISO 8601 UTC string (suffixed with Z). See feed comment for details.
     timestamp: v.string(),
     type: v.literal('diaper_change'),
     diaperChange: v.object({
@@ -64,6 +68,7 @@ const activityValidator = v.union(
   }),
   // medical activity
   v.object({
+    // ISO 8601 UTC string (suffixed with Z). See feed comment for details.
     timestamp: v.string(),
     type: v.literal('medical'),
     medical: v.union(
@@ -193,6 +198,11 @@ export const getLast24hSummary = query({
  * Get all activities for the authenticated user's family within a timestamp range.
  * Returns activities ordered by timestamp descending (newest first).
  * Used for day-based pagination on the home page.
+ *
+ * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z) so that
+ * the Convex string-index comparison against the stored UTC timestamps is correct.
+ * Passing local-offset strings (e.g. +08:00) causes incorrect filtering for users
+ * with non-UTC timezones (see the app home page timezone bug fix).
  */
 export const getActivitiesByDateRange = query({
   args: {

--- a/services/backend/src/domain/activity/Activity.ts
+++ b/services/backend/src/domain/activity/Activity.ts
@@ -54,18 +54,21 @@ export type MedicalPayload = TemperaturePayload | MedicinePayload;
 export type ActivityType = 'feed' | 'diaper_change' | 'medical';
 
 export interface FeedActivity {
+  /** ISO 8601 UTC string (suffixed with Z). Normalized by the Create/Update use cases. */
   timestamp: string;
   type: 'feed';
   feed: FeedPayload;
 }
 
 export interface DiaperChangeActivity {
+  /** ISO 8601 UTC string (suffixed with Z). Normalized by the Create/Update use cases. */
   timestamp: string;
   type: 'diaper_change';
   diaperChange: DiaperChangePayload;
 }
 
 export interface MedicalActivity {
+  /** ISO 8601 UTC string (suffixed with Z). Normalized by the Create/Update use cases. */
   timestamp: string;
   type: 'medical';
   medical: MedicalPayload;

--- a/services/backend/src/domain/activity/Activity.ts
+++ b/services/backend/src/domain/activity/Activity.ts
@@ -54,22 +54,22 @@ export type MedicalPayload = TemperaturePayload | MedicinePayload;
 export type ActivityType = 'feed' | 'diaper_change' | 'medical';
 
 export interface FeedActivity {
-  /** ISO 8601 UTC string (suffixed with Z). Normalized by the Create/Update use cases. */
-  timestamp: string;
+  /** Epoch milliseconds (UTC). Converted to/from ISO strings by the repository layer. */
+  timestamp: number;
   type: 'feed';
   feed: FeedPayload;
 }
 
 export interface DiaperChangeActivity {
-  /** ISO 8601 UTC string (suffixed with Z). Normalized by the Create/Update use cases. */
-  timestamp: string;
+  /** Epoch milliseconds (UTC). Converted to/from ISO strings by the repository layer. */
+  timestamp: number;
   type: 'diaper_change';
   diaperChange: DiaperChangePayload;
 }
 
 export interface MedicalActivity {
-  /** ISO 8601 UTC string (suffixed with Z). Normalized by the Create/Update use cases. */
-  timestamp: string;
+  /** Epoch milliseconds (UTC). Converted to/from ISO strings by the repository layer. */
+  timestamp: number;
   type: 'medical';
   medical: MedicalPayload;
 }

--- a/services/backend/src/domain/repositories/IActivityRepository.ts
+++ b/services/backend/src/domain/repositories/IActivityRepository.ts
@@ -46,17 +46,16 @@ export interface IActivityRepository {
   ): Promise<PaginationResult<Activity>>;
 
   /**
-   * List activities whose timestamp falls within [fromIso, toIso] (inclusive),
+   * List activities whose timestamp falls within [fromMs, toMs] (inclusive, epoch ms),
    * ordered by timestamp ascending. Returns ALL matching activities (no pagination).
    * Intended for bounded windows like "last 24h".
    *
-   * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z) so that
-   * the Convex string-index comparison against the stored UTC timestamps is correct.
-   * The stored activity.timestamp field is normalised to UTC by the Create/Update use cases.
+   * The implementation converts fromMs/toMs to ISO 8601 UTC strings for the Convex
+   * string-index comparison against the stored UTC timestamps.
    */
   listByTimestampRange(
     deviceId: string,
-    fromIso: string,
-    toIso: string
+    fromMs: number,
+    toMs: number
   ): Promise<Activity[]>;
 }

--- a/services/backend/src/domain/repositories/IActivityRepository.ts
+++ b/services/backend/src/domain/repositories/IActivityRepository.ts
@@ -49,6 +49,10 @@ export interface IActivityRepository {
    * List activities whose timestamp falls within [fromIso, toIso] (inclusive),
    * ordered by timestamp ascending. Returns ALL matching activities (no pagination).
    * Intended for bounded windows like "last 24h".
+   *
+   * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z) so that
+   * the Convex string-index comparison against the stored UTC timestamps is correct.
+   * The stored activity.timestamp field is normalised to UTC by the Create/Update use cases.
    */
   listByTimestampRange(
     deviceId: string,

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.spec.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { computeLast24hSummary, type Last24hSummary } from './ComputeLast24hSummary';
 
 function makeFeed(ts: string, subType: string, extras: Record<string, unknown> = {}) {
-  return { type: 'feed' as const, timestamp: ts, feed: { type: subType, ...extras } };
+  return { type: 'feed' as const, timestamp: Date.parse(ts), feed: { type: subType, ...extras } };
 }
 
 function makeDiaper(ts: string, diaperType: string) {
-  return { type: 'diaper_change' as const, timestamp: ts, diaperChange: { type: diaperType } };
+  return { type: 'diaper_change' as const, timestamp: Date.parse(ts), diaperChange: { type: diaperType } };
 }
 
 function makeTemp(ts: string, value: number) {
-  return { type: 'medical' as const, timestamp: ts, medical: { type: 'temperature' as const, temperature: { value } } };
+  return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'temperature' as const, temperature: { value } } };
 }
 
 describe('computeLast24hSummary', () => {

--- a/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/ComputeLast24hSummary.ts
@@ -34,7 +34,7 @@ export function computeLast24hSummary(
   const threeHourBoundaryMs = nowMs - 3 * 60 * 60 * 1000;
 
   for (const activity of activities) {
-    const tsMs = Date.parse(activity.timestamp);
+    const tsMs = activity.timestamp;
     if (tsMs <= nowMs && tsMs > windowStartMs) {
       if (activity.type === 'feed') {
         if (tsMs > (lastFeedAtMs ?? 0)) {

--- a/services/backend/src/domain/usecases/activity/CreateActivity.ts
+++ b/services/backend/src/domain/usecases/activity/CreateActivity.ts
@@ -1,6 +1,15 @@
 /**
  * Usecase: Create a new activity for a device.
  * Validates the timestamp (business logic) before delegating to the repository.
+ *
+ * IMPORTANT: The timestamp is normalised to UTC before storing.
+ * All query surfaces that filter by timestamp must pass ISO 8601 UTC strings
+ * (suffixed with Z) so that the Convex string-index comparison is correct.
+ *
+ * See also:
+ *   - UpdateActivity.ts (same UTC normalisation)
+ *   - GetLast24hSummary.ts (query bounds must be UTC)
+ *   - IActivityRepository.listByTimestampRange (fromIso/toIso docs)
  */
 import { DateTime } from 'luxon';
 import type { IActivityRepository } from '../../repositories/IActivityRepository';
@@ -17,6 +26,8 @@ export async function createActivity(
   }
   return repo.create(deviceId, {
     ...activity,
+    // Normalise to UTC so string-index queries work correctly.
+    // The client may send any ISO 8601 format (Z, +HH:MM, or bare local).
     timestamp: ts.toUTC().toISO()!,
   });
 }

--- a/services/backend/src/domain/usecases/activity/CreateActivity.ts
+++ b/services/backend/src/domain/usecases/activity/CreateActivity.ts
@@ -1,17 +1,10 @@
 /**
  * Usecase: Create a new activity for a device.
- * Validates the timestamp (business logic) before delegating to the repository.
+ * Delegates to the repository, which handles the timestamp format conversion.
  *
- * IMPORTANT: The timestamp is normalised to UTC before storing.
- * All query surfaces that filter by timestamp must pass ISO 8601 UTC strings
- * (suffixed with Z) so that the Convex string-index comparison is correct.
- *
- * See also:
- *   - UpdateActivity.ts (same UTC normalisation)
- *   - GetLast24hSummary.ts (query bounds must be UTC)
- *   - IActivityRepository.listByTimestampRange (fromIso/toIso docs)
+ * The domain operates on epoch milliseconds. The repository converts between
+ * epoch ms and ISO 8601 UTC strings for Convex storage.
  */
-import { DateTime } from 'luxon';
 import type { IActivityRepository } from '../../repositories/IActivityRepository';
 import type { Activity } from '../../activity/Activity';
 
@@ -20,14 +13,5 @@ export async function createActivity(
   deviceId: string,
   activity: Activity
 ): Promise<string> {
-  const ts = DateTime.fromISO(activity.timestamp);
-  if (!ts.isValid) {
-    throw new Error(`invalid timestamp: ${activity.timestamp}`);
-  }
-  return repo.create(deviceId, {
-    ...activity,
-    // Normalise to UTC so string-index queries work correctly.
-    // The client may send any ISO 8601 format (Z, +HH:MM, or bare local).
-    timestamp: ts.toUTC().toISO()!,
-  });
+  return repo.create(deviceId, activity);
 }

--- a/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
@@ -7,8 +7,14 @@ export async function getLast24hSummary(
   repo: IActivityRepository,
   nowMs: number
 ): Promise<Last24hSummary> {
-  const fromIso = DateTime.fromMillis(nowMs - 24 * 60 * 60 * 1000).toISO()!;
-  const toIso = DateTime.fromMillis(nowMs).toISO()!;
+  // IMPORTANT: .toUTC() is required here because the stored activity.timestamp
+  // is normalised to UTC (see CreateActivity.ts). Without .toUTC(), the offset
+  // would depend on the server's local timezone, producing a local-offset ISO
+  // string that breaks the Convex string-index comparison against UTC timestamps.
+  // On most systems (including Convex servers) the local timezone is UTC, so
+  // this happens to work today, but we explicitly force UTC for correctness.
+  const fromIso = DateTime.fromMillis(nowMs - 24 * 60 * 60 * 1000).toUTC().toISO()!;
+  const toIso = DateTime.fromMillis(nowMs).toUTC().toISO()!;
   const activities = await repo.listByTimestampRange('', fromIso, toIso);
   return computeLast24hSummary(activities, nowMs);
 }

--- a/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
+++ b/services/backend/src/domain/usecases/activity/GetLast24hSummary.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import type { IActivityRepository } from '../../repositories/IActivityRepository';
 import type { Last24hSummary } from './ComputeLast24hSummary';
 import { computeLast24hSummary } from './ComputeLast24hSummary';
@@ -7,14 +6,7 @@ export async function getLast24hSummary(
   repo: IActivityRepository,
   nowMs: number
 ): Promise<Last24hSummary> {
-  // IMPORTANT: .toUTC() is required here because the stored activity.timestamp
-  // is normalised to UTC (see CreateActivity.ts). Without .toUTC(), the offset
-  // would depend on the server's local timezone, producing a local-offset ISO
-  // string that breaks the Convex string-index comparison against UTC timestamps.
-  // On most systems (including Convex servers) the local timezone is UTC, so
-  // this happens to work today, but we explicitly force UTC for correctness.
-  const fromIso = DateTime.fromMillis(nowMs - 24 * 60 * 60 * 1000).toUTC().toISO()!;
-  const toIso = DateTime.fromMillis(nowMs).toUTC().toISO()!;
-  const activities = await repo.listByTimestampRange('', fromIso, toIso);
+  const fromMs = nowMs - 24 * 60 * 60 * 1000;
+  const activities = await repo.listByTimestampRange('', fromMs, nowMs);
   return computeLast24hSummary(activities, nowMs);
 }

--- a/services/backend/src/domain/usecases/activity/UpdateActivity.ts
+++ b/services/backend/src/domain/usecases/activity/UpdateActivity.ts
@@ -1,12 +1,10 @@
 /**
  * Usecase: Update an existing activity.
- * Validates the timestamp (business logic) before delegating to the repository.
+ * Delegates to the repository, which handles the timestamp format conversion.
  *
- * IMPORTANT: The timestamp is normalised to UTC before storing, identical to
- * CreateActivity.ts. All query surfaces that filter by timestamp must pass
- * ISO 8601 UTC strings (suffixed with Z) for correct string-index comparison.
+ * The domain operates on epoch milliseconds. The repository converts between
+ * epoch ms and ISO 8601 UTC strings for Convex storage.
  */
-import { DateTime } from 'luxon';
 import type { IActivityRepository } from '../../repositories/IActivityRepository';
 import type { Activity } from '../../activity/Activity';
 
@@ -16,13 +14,5 @@ export async function updateActivity(
   activityId: string,
   activity: Activity
 ): Promise<void> {
-  const ts = DateTime.fromISO(activity.timestamp);
-  if (!ts.isValid) {
-    throw new Error(`invalid timestamp: ${activity.timestamp}`);
-  }
-  await repo.update(deviceId, activityId, {
-    ...activity,
-    // Normalise to UTC, matching CreateActivity behaviour.
-    timestamp: ts.toUTC().toISO()!,
-  });
+  await repo.update(deviceId, activityId, activity);
 }

--- a/services/backend/src/domain/usecases/activity/UpdateActivity.ts
+++ b/services/backend/src/domain/usecases/activity/UpdateActivity.ts
@@ -1,6 +1,10 @@
 /**
  * Usecase: Update an existing activity.
  * Validates the timestamp (business logic) before delegating to the repository.
+ *
+ * IMPORTANT: The timestamp is normalised to UTC before storing, identical to
+ * CreateActivity.ts. All query surfaces that filter by timestamp must pass
+ * ISO 8601 UTC strings (suffixed with Z) for correct string-index comparison.
  */
 import { DateTime } from 'luxon';
 import type { IActivityRepository } from '../../repositories/IActivityRepository';
@@ -18,6 +22,7 @@ export async function updateActivity(
   }
   await repo.update(deviceId, activityId, {
     ...activity,
+    // Normalise to UTC, matching CreateActivity behaviour.
     timestamp: ts.toUTC().toISO()!,
   });
 }

--- a/services/backend/src/infra/ConvexActivityRepository.ts
+++ b/services/backend/src/infra/ConvexActivityRepository.ts
@@ -1,6 +1,12 @@
 /**
  * Convex implementation of IActivityRepository.
  * Uses the existing activityStreamForDevice helper to resolve device → activity stream.
+ *
+ * ── Timestamp conversion ───────────────────────────────────────
+ * The domain operates on epoch-ms timestamps (number). Convex stores ISO 8601
+ * UTC strings (v.string()). The conversion happens in this layer via toStorage()
+ * and convertDoc(). See ConvexWebActivityRepository for detailed docs on the
+ * approach and the minimal cast needed for nested payload fields.
  */
 import type { GenericMutationCtx, GenericQueryCtx, GenericDatabaseWriter } from 'convex/server';
 import type { DataModel, Id } from '../../convex/_generated/dataModel';
@@ -11,6 +17,46 @@ import type { Activity } from '../domain/activity/Activity';
 
 type Ctx = GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>;
 
+// ── Timestamp conversion helpers ──────────────────────────────────────────────
+
+function toIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function toMs(iso: string): number {
+  return Date.parse(iso);
+}
+
+function toStorage(activity: Activity) {
+  const ts = toIso(activity.timestamp);
+  if (activity.type === 'feed') {
+    return { type: 'feed' as const, timestamp: ts, feed: activity.feed };
+  }
+  if (activity.type === 'diaper_change') {
+    return { type: 'diaper_change' as const, timestamp: ts, diaperChange: activity.diaperChange };
+  }
+  return { type: 'medical' as const, timestamp: ts, medical: activity.medical };
+}
+
+function convertDoc(doc: {
+  activity:
+    | { type: 'feed'; timestamp: string; feed: unknown }
+    | { type: 'diaper_change'; timestamp: string; diaperChange: unknown }
+    | { type: 'medical'; timestamp: string; medical: unknown };
+}): Activity {
+  const act = doc.activity;
+  const ts = toMs(act.timestamp);
+  if (act.type === 'feed') {
+    return { type: 'feed' as const, timestamp: ts, feed: act.feed as any };
+  }
+  if (act.type === 'diaper_change') {
+    return { type: 'diaper_change' as const, timestamp: ts, diaperChange: act.diaperChange as any };
+  }
+  return { type: 'medical' as const, timestamp: ts, medical: act.medical as any };
+}
+
+// ── Repository ─────────────────────────────────────────────────────────────────
+
 export class ConvexActivityRepository implements IActivityRepository {
   constructor(private ctx: Ctx) {}
 
@@ -19,11 +65,10 @@ export class ConvexActivityRepository implements IActivityRepository {
     if (!stream) {
       throw new Error(`activity stream not found for device: ${deviceId}`);
     }
-    // MutationCtx is required for insert — safe cast since callers always provide it
     const db = this.ctx.db as GenericDatabaseWriter<DataModel>;
     const id = await db.insert('activities', {
       activityStreamId: stream._id,
-      activity: activity as any, // domain Activity shape matches Convex activity field
+      activity: toStorage(activity),
     });
     return id;
   }
@@ -40,7 +85,7 @@ export class ConvexActivityRepository implements IActivityRepository {
     const db = this.ctx.db as GenericDatabaseWriter<DataModel>;
     await db.replace(activityId as Id<'activities'>, {
       activityStreamId: stream._id,
-      activity: activity as any,
+      activity: toStorage(activity),
     });
   }
 
@@ -56,7 +101,7 @@ export class ConvexActivityRepository implements IActivityRepository {
     });
     const doc = await this.ctx.db.get(activityId as Id<'activities'>);
     if (!doc) return null;
-    return doc.activity as Activity;
+    return convertDoc(doc);
   }
 
   async listByDeviceTimestampDesc(
@@ -76,36 +121,34 @@ export class ConvexActivityRepository implements IActivityRepository {
       .paginate(paginationOpts);
 
     return {
-      page: result.page.map((doc) => doc.activity as Activity),
+      page: result.page.map((doc) => ({ ...convertDoc(doc), _id: doc._id })),
       isDone: result.isDone,
       continueCursor: result.continueCursor,
     };
   }
 
-  /**
-   * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z).
-   * The stored activity.timestamp is normalised to UTC by the Create/Update use cases.
-   */
   async listByTimestampRange(
     deviceId: string,
-    fromIso: string,
-    toIso: string
+    fromMs: number,
+    toMs: number
   ): Promise<Activity[]> {
     const stream = await activityStreamForDevice(this.ctx, { deviceId });
     if (!stream) {
       throw new Error(`activity stream not found for device: ${deviceId}`);
     }
+    const fromIso = toIso(fromMs);
+    const toIso_ = toIso(toMs);
     const docs = await this.ctx.db
       .query('activities')
       .withIndex('by_activityStreamId_by_timestamp', (q) =>
         q
           .eq('activityStreamId', stream._id)
           .gte('activity.timestamp', fromIso)
-          .lte('activity.timestamp', toIso)
+          .lte('activity.timestamp', toIso_)
       )
       .order('asc')
       .collect();
 
-    return docs.map((doc) => doc.activity as Activity);
+    return docs.map((doc) => convertDoc(doc));
   }
 }

--- a/services/backend/src/infra/ConvexActivityRepository.ts
+++ b/services/backend/src/infra/ConvexActivityRepository.ts
@@ -82,6 +82,10 @@ export class ConvexActivityRepository implements IActivityRepository {
     };
   }
 
+  /**
+   * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z).
+   * The stored activity.timestamp is normalised to UTC by the Create/Update use cases.
+   */
   async listByTimestampRange(
     deviceId: string,
     fromIso: string,

--- a/services/backend/src/infra/ConvexWebActivityRepository.ts
+++ b/services/backend/src/infra/ConvexWebActivityRepository.ts
@@ -5,6 +5,15 @@
  * The web endpoint calls requireAuthAndFamily first to obtain activityStreamId,
  * then passes it to the constructor. This avoids repeated DB lookups inside
  * each method and keeps the repository focused on data access.
+ *
+ * ── Timestamp conversion ───────────────────────────────────────
+ * The domain operates on epoch-ms timestamps (number). Convex stores ISO 8601
+ * UTC strings (v.string()). The conversion between the two happens in this
+ * layer: toStorage() maps domain → storage and convertDoc() maps storage → domain.
+ * Both functions narrow the discriminated union explicitly so that TypeScript
+ * can verify the shape. A minimal cast (`act.feed as any`) is needed for the
+ * nested payload fields because their runtime shape matches but TypeScript's
+ * inference of the Convex document type is too generic to verify statically.
  */
 import type { GenericMutationCtx, GenericQueryCtx, GenericDatabaseWriter } from 'convex/server';
 import type { DataModel, Id } from '../../convex/_generated/dataModel';
@@ -13,6 +22,56 @@ import type { Activity } from '../domain/activity/Activity';
 import { ConvexError } from 'convex/values';
 
 type Ctx = GenericMutationCtx<DataModel> | GenericQueryCtx<DataModel>;
+
+/** Epoch ms → ISO 8601 UTC string for Convex storage. */
+function toIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+/** ISO 8601 UTC string → epoch ms for the domain. */
+function toMs(iso: string): number {
+  return Date.parse(iso);
+}
+
+/**
+ * Convert a domain Activity (epoch-ms timestamp) to the Convex storage shape
+ * (ISO 8601 UTC string timestamp). Each member of the discriminated union is
+ * handled explicitly so TypeScript can verify the returned shape.
+ */
+function toStorage(activity: Activity) {
+  const ts = toIso(activity.timestamp);
+  if (activity.type === 'feed') {
+    return { type: 'feed' as const, timestamp: ts, feed: activity.feed };
+  }
+  if (activity.type === 'diaper_change') {
+    return { type: 'diaper_change' as const, timestamp: ts, diaperChange: activity.diaperChange };
+  }
+  return { type: 'medical' as const, timestamp: ts, medical: activity.medical };
+}
+
+/**
+ * Convert a stored Convex activity document to a domain Activity (epoch-ms timestamp).
+ * The `as any` on nested payload fields is required because the Convex Doc type
+ * infers the activity union generically, and TypeScript cannot statically prove
+ * the payload shape matches the domain type after the timestamp field is remapped.
+ * At runtime the shapes are identical — only the timestamp type differs.
+ */
+function convertDoc(doc: {
+  activity:
+    | { type: 'feed'; timestamp: string; feed: unknown }
+    | { type: 'diaper_change'; timestamp: string; diaperChange: unknown }
+    | { type: 'medical'; timestamp: string; medical: unknown };
+}): Activity {
+  const act = doc.activity;
+  const ts = toMs(act.timestamp);
+  if (act.type === 'feed') {
+    return { type: 'feed' as const, timestamp: ts, feed: act.feed as any };
+  }
+  if (act.type === 'diaper_change') {
+    return { type: 'diaper_change' as const, timestamp: ts, diaperChange: act.diaperChange as any };
+  }
+  return { type: 'medical' as const, timestamp: ts, medical: act.medical as any };
+}
 
 export class ConvexWebActivityRepository implements IActivityRepository {
   constructor(
@@ -37,7 +96,7 @@ export class ConvexWebActivityRepository implements IActivityRepository {
   async create(_deviceId: string, activity: Activity): Promise<string> {
     const id = await this.dbWriter.insert('activities', {
       activityStreamId: this.activityStreamId,
-      activity: activity,
+      activity: toStorage(activity),
     });
     return id;
   }
@@ -56,16 +115,13 @@ export class ConvexWebActivityRepository implements IActivityRepository {
     }
     await this.dbWriter.replace(this.actId(activityId), {
       activityStreamId: this.activityStreamId,
-      activity: activity,
+      activity: toStorage(activity),
     });
   }
 
   /**
    * Delete an activity by ID. Verifies the activity belongs to this
    * repository's activity stream before allowing the deletion.
-   *
-   * @throws ConvexError({ code: 'NOT_FOUND' }) if the activity does not exist
-   * @throws ConvexError({ code: 'FORBIDDEN' }) if the activity belongs to a different stream
    */
   async delete(activityId: string): Promise<void> {
     const doc = await this.ctx.db.get(this.actId(activityId));
@@ -80,13 +136,12 @@ export class ConvexWebActivityRepository implements IActivityRepository {
 
   /**
    * Get a single activity by ID, scoped to this repository's activity stream.
-   * Returns null if the activity doesn't exist or belongs to a different stream.
    */
   async getById(_deviceId: string, activityId: string): Promise<Activity | null> {
     const doc = await this.ctx.db.get(this.actId(activityId));
     if (!doc) return null;
     if (doc.activityStreamId !== this.activityStreamId) return null;
-    return doc.activity;
+    return convertDoc(doc);
   }
 
   /**
@@ -106,7 +161,7 @@ export class ConvexWebActivityRepository implements IActivityRepository {
       .paginate(paginationOpts);
 
     return {
-      page: result.page.map((doc) => ({ ...doc.activity, _id: doc._id })),
+      page: result.page.map((doc) => ({ ...convertDoc(doc), _id: doc._id })),
       isDone: result.isDone,
       continueCursor: result.continueCursor,
     };
@@ -114,27 +169,26 @@ export class ConvexWebActivityRepository implements IActivityRepository {
 
   /**
    * List ALL activities in the repository's activity stream whose timestamp
-   * falls within [fromIso, toIso] (inclusive), ordered by timestamp ascending.
-   *
-   * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z).
-   * The stored activity.timestamp is normalised to UTC by the Create/Update use cases.
+   * falls within [fromMs, toMs] (inclusive, epoch ms), ordered by timestamp ascending.
    */
   async listByTimestampRange(
     _deviceId: string,
-    fromIso: string,
-    toIso: string
+    fromMs: number,
+    toMs: number
   ): Promise<Activity[]> {
+    const fromIso = toIso(fromMs);
+    const toIso_ = toIso(toMs);
     const docs = await this.ctx.db
       .query('activities')
       .withIndex('by_activityStreamId_by_timestamp', (q) =>
         q
           .eq('activityStreamId', this.activityStreamId)
           .gte('activity.timestamp', fromIso)
-          .lte('activity.timestamp', toIso)
+          .lte('activity.timestamp', toIso_)
       )
       .order('asc')
       .collect();
 
-    return docs.map((doc) => doc.activity);
+    return docs.map((doc) => convertDoc(doc));
   }
 }

--- a/services/backend/src/infra/ConvexWebActivityRepository.ts
+++ b/services/backend/src/infra/ConvexWebActivityRepository.ts
@@ -115,6 +115,9 @@ export class ConvexWebActivityRepository implements IActivityRepository {
   /**
    * List ALL activities in the repository's activity stream whose timestamp
    * falls within [fromIso, toIso] (inclusive), ordered by timestamp ascending.
+   *
+   * Both fromIso and toIso must be ISO 8601 UTC strings (suffixed with Z).
+   * The stored activity.timestamp is normalised to UTC by the Create/Update use cases.
    */
   async listByTimestampRange(
     _deviceId: string,


### PR DESCRIPTION
## Summary

Moves all ISO-string ↔ epoch-ms conversion out of the use case layer and into the repository layer. The domain now operates on epoch milliseconds (`number`) instead of ISO 8601 UTC strings.

## Why

This eliminates the smell of double timezone conversion (frontend adds offset → use case strips it) and centralizes all timestamp format handling in one place — the repository.

## Changes

### Domain
- `Activity.timestamp`: `string` → `number` (epoch ms)
- `IActivityRepository.listByTimestampRange`: `fromIso/toIso: string` → `fromMs/toMs: number`

### Use cases
- `CreateActivity`, `UpdateActivity`, `GetLast24hSummary`: removed all `DateTime.fromISO/toUTC` conversions — just pass through

### Repository layer
- Both `ConvexWebActivityRepository` and `ConvexActivityRepository`:
  - `toStorage()`: converts domain Activity (epoch ms) → storage shape (ISO string)
  - `convertDoc()`: converts storage doc (ISO string) → domain Activity (epoch ms)
  - Both use discriminated union narrowing for type safety

### API endpoints
- Validators: `timestamp: v.string()` → `v.number()`
- Query args: `fromIso/toIso` → `fromMs/toMs`, `nowIso` → `nowMs`

### Frontend
- `toTimestamp()` returns epoch ms (number)
- `formatTime/formatDate/toLocalDatetimeString` accept `number | string`
- `useNowBucket5Min()` returns number (epoch ms) directly
- `page.tsx`: sends `fromMs/toMs` instead of `fromIso/toIso`

### Note
The generated Convex API types still reflect the deployed function signatures (with `v.string()`). A `npx convex deploy` + codegen is needed to update them. After that, the 6 remaining type errors will resolve.
