### PR TITLE
feat(webapp): show total latch duration in 24h summary feed column

### DIFF
--- a/apps/webapp/src/lib/daily-summary.spec.ts
+++ b/apps/webapp/src/lib/daily-summary.spec.ts
@@ -427,6 +427,9 @@ describe('computeLast24hSummary', () => {
     expect(result.feed.last3hMl).toBe(0);
     expect(result.feed.total24hMl).toBe(0);
     expect(result.feed.bottleCount).toBe(0);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
     expect(result.diapers).toEqual({ wet: 0, dirty: 0, mixed: 0, total: 0 });
   });
 
@@ -441,6 +444,9 @@ describe('computeLast24hSummary', () => {
     expect(result.feed.bottleCount).toBe(3);
     expect(result.feed.total24hMl).toBe(180);
     expect(result.feed.last3hMl).toBe(30);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
   });
 
   it('excludes activities older than 24h', () => {
@@ -453,6 +459,43 @@ describe('computeLast24hSummary', () => {
     const result = computeLast24hSummary(activities, nowMs);
     expect(result.feed.bottleCount).toBe(1);
     expect(result.feed.total24hMl).toBe(120);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
     expect(result.diapers).toEqual({ wet: 0, dirty: 0, mixed: 0, total: 0 });
+  });
+
+  it('aggregates latch duration over 3h and 24h windows', () => {
+    const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+    // 1h ago → within 3h window
+    const oneHourAgo = '2025-01-15T11:00:00.000Z';
+    // 6h ago → within 24h but outside 3h window
+    const sixHoursAgo = '2025-01-15T06:00:00.000Z';
+    // 30h ago → outside 24h window
+    const thirtyHoursAgo = '2025-01-14T06:00:00.000Z';
+    const activities = [
+      makeFeed(oneHourAgo, 'latch', { duration: { left: { seconds: 300 }, right: { seconds: 180 } } }),
+      makeFeed(sixHoursAgo, 'latch', { duration: { left: { seconds: 120 }, right: { seconds: 60 } } }),
+      makeFeed(thirtyHoursAgo, 'latch', { duration: { left: { seconds: 900 }, right: { seconds: 900 } } }),
+    ] as Activity[];
+    const result = computeLast24hSummary(activities, nowMs);
+    // 300+180 (1h ago) + 120+60 (6h ago) = 660s total24h
+    expect(result.feed.total24hLatchSeconds).toBe(660);
+    // Only 300+180 (1h ago) = 480s in last 3h
+    expect(result.feed.last3hLatchSeconds).toBe(480);
+    expect(result.feed.latchCount).toBe(2);
+  });
+
+  it('does not contribute bottle feed to latch totals', () => {
+    const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+    const oneHourAgo = '2025-01-15T11:00:00.000Z';
+    const activities = [
+      makeFeed(oneHourAgo, 'expressed', { volume: { ml: 90 } }),
+      makeFeed(oneHourAgo, 'formula', { volume: { ml: 60 } }),
+    ] as Activity[];
+    const result = computeLast24hSummary(activities, nowMs);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
   });
 });

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -357,6 +357,9 @@ export interface Last24hSummary {
     last3hMl: number;
     total24hMl: number;
     bottleCount: number;
+    last3hLatchSeconds: number;
+    total24hLatchSeconds: number;
+    latchCount: number;
   };
   diapers: {
     wet: number;
@@ -384,6 +387,9 @@ export function computeLast24hSummary(
   let total24hMl = 0;
   let last3hMl = 0;
   let bottleCount = 0;
+  let total24hLatchSeconds = 0;
+  let last3hLatchSeconds = 0;
+  let latchCount = 0;
   let wet = 0, dirty = 0, mixed = 0;
 
   for (const activity of activities) {
@@ -397,6 +403,11 @@ export function computeLast24hSummary(
           total24hMl += vol;
           if (tsMs > threeHourBoundaryMs) last3hMl += vol;
           bottleCount++;
+        } else if (feedType === 'latch') {
+          const latchSeconds = ((activity.feed.duration?.left?.seconds ?? 0) + (activity.feed.duration?.right?.seconds ?? 0));
+          total24hLatchSeconds += latchSeconds;
+          if (tsMs > threeHourBoundaryMs) last3hLatchSeconds += latchSeconds;
+          latchCount++;
         }
       } else if (activity.type === 'diaper_change') {
         const dType = activity.diaperChange.type;
@@ -408,7 +419,7 @@ export function computeLast24hSummary(
   }
 
   return {
-    feed: { lastFeedAtMs, last3hMl, total24hMl, bottleCount },
+    feed: { lastFeedAtMs, last3hMl, total24hMl, bottleCount, last3hLatchSeconds, total24hLatchSeconds, latchCount },
     diapers: { wet, dirty, mixed, total: wet + dirty + mixed },
   };
 }

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -15,9 +15,9 @@ describe('Last24hSummaryCard', () => {
   });
 
 
-  it('renders all 6 rows even when all values are empty or zero', () => {
+  it('renders all 8 rows even when all values are empty or zero', () => {
     const summary = {
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     const { container } = render(
@@ -25,44 +25,48 @@ describe('Last24hSummaryCard', () => {
     );
     expect(container.firstChild).not.toBeNull();
     expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.getByText(/3h:/)).toBeInTheDocument();
-    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getByText(/3h ml:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h ml:/)).toBeInTheDocument();
+    expect(screen.getByText(/3h latch:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h latch:/)).toBeInTheDocument();
     expect(screen.getByText('Wet:')).toBeInTheDocument();
     expect(screen.getByText('Mixed:')).toBeInTheDocument();
     expect(screen.getByText('Dirty:')).toBeInTheDocument();
-    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(6);
+    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(8);
   });
 
   it('renders feed stats when values are non-zero', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1200, latchCount: 3 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('Last 24h')).toBeInTheDocument();
     expect(screen.getByText(/Last:/)).toBeInTheDocument();
-    expect(screen.getByText(/3h:/)).toBeInTheDocument();
+    expect(screen.getByText(/3h ml:/)).toBeInTheDocument();
     expect(screen.getByText(/90 ml/)).toBeInTheDocument();
-    expect(screen.getByText(/24h:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h ml:/)).toBeInTheDocument();
     expect(screen.getByText(/240 ml/)).toBeInTheDocument();
+    expect(screen.getByText(/3h latch:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h latch:/)).toBeInTheDocument();
     expect(screen.getByText(/^\d+h( \d+min)? ago$/)).toBeInTheDocument();
   });
 
   it('renders non-zero values alongside em-dashes for zero values', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 0, mixed: 0, total: 2 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('1h ago')).toBeInTheDocument();
     expect(screen.getAllByText(/60 ml/)).toHaveLength(2);
     expect(screen.getByText(/^2$/)).toBeInTheDocument();
-    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(2);
+    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(4);
   });
 
   it('renders no em-dashes when all values are non-zero', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 300, total24hLatchSeconds: 900, latchCount: 4 },
       diapers: { wet: 2, dirty: 1, mixed: 3, total: 6 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -71,7 +75,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders diaper labels in DOM order', () => {
     const summary = {
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, mixed: 1, dirty: 3, total: 6 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -82,9 +86,9 @@ describe('Last24hSummaryCard', () => {
     expect(labels[2].textContent).toBe('Dirty:');
   });
 
-  it('applies font-medium only to volume values, not time-ago', () => {
+  it('applies font-medium only to values, not time-ago', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 300, total24hLatchSeconds: 600, latchCount: 2 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -99,7 +103,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders large diaper counts correctly', () => {
     const summary = {
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 99, mixed: 99, dirty: 99, total: 297 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -111,12 +115,35 @@ describe('Last24hSummaryCard', () => {
 
   it('applies dark mode classes via semantic color tokens', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
     };
     const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const root = container.firstChild as Element;
     expect(root.className).toMatch(/bg-rose-50/);
     expect(root.className).toMatch(/dark:bg-rose-950/);
+  });
+
+  it('renders latch duration rows with formatted values when present', () => {
+    const summary = {
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 480, total24hLatchSeconds: 1200, latchCount: 3 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/3h latch:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h latch:/)).toBeInTheDocument();
+    expect(screen.getByText(/8 min 0 sec/)).toBeInTheDocument();
+    expect(screen.getByText(/20 min 0 sec/)).toBeInTheDocument();
+  });
+
+  it('shows dash for latch rows when there are no latch sessions', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/3h latch:/)).toBeInTheDocument();
+    expect(screen.getByText(/24h latch:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(8);
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -2,7 +2,7 @@
 
 import { Milk, Baby, Clock } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
-import { timeAgoFromMs } from '@/lib/activity-form-utils';
+import { timeAgoFromMs, formatDuration } from '@/lib/activity-form-utils';
 import type { Last24hSummary } from '@/lib/daily-summary';
 
 const DASH = '\u2014';
@@ -28,12 +28,14 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
             <Skeleton className="h-3 w-full" />
             <Skeleton className="h-3 w-3/4" />
             <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="h-3 w-2/3" />
           </div>
           <div className="space-y-1.5">
             <Skeleton className="h-3 w-12" />
             <Skeleton className="h-3 w-full" />
             <Skeleton className="h-3 w-3/4" />
             <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="h-3 w-2/3" />
           </div>
         </div>
       </div>
@@ -62,13 +64,21 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
                 <span className="text-foreground">
                   {feed.lastFeedAtMs !== null ? timeAgoFromMs(nowMs - feed.lastFeedAtMs) : DASH}
                 </span>
-                <span>3h:</span>
+                <span>3h ml:</span>
                 <span className="font-medium text-foreground">
                   {feed.last3hMl > 0 ? `${feed.last3hMl} ml` : DASH}
                 </span>
-                <span>24h:</span>
+                <span>24h ml:</span>
                 <span className="font-medium text-foreground">
                   {feed.bottleCount >= 1 ? `${feed.total24hMl} ml` : DASH}
+                </span>
+                <span>3h latch:</span>
+                <span className="font-medium text-foreground">
+                  {feed.last3hLatchSeconds > 0 ? formatDuration(feed.last3hLatchSeconds) : DASH}
+                </span>
+                <span>24h latch:</span>
+                <span className="font-medium text-foreground">
+                  {feed.latchCount >= 1 ? formatDuration(feed.total24hLatchSeconds) : DASH}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
The Feed column in the 24h summary card now shows total latch duration for the past 3 hours and 24 hours alongside the existing volume (ml) rows.

**What changed:**
- "3h ml:" and "24h ml:" labels replace the ambiguous "3h:" / "24h:"
- New "3h latch:" and "24h latch:" rows display formatted duration (e.g. "8 min 0 sec")
- Latch rows show an em-dash when no latch sessions exist (mirrors bottle row behavior)

**Aggregation:**
- `computeLast24hSummary` extends the `Last24hSummary.feed` type with `last3hLatchSeconds`, `total24hLatchSeconds`, and `latchCount`
- Latch duration sums (left+right seconds) mirror the bottle volume aggregation pattern

**Tests added:**
- Latch aggregation over 3h and 24h windows (including boundary exclusion)
- Bottle-only feeds do not contribute to latch totals
- Latch row rendering with formatted values
- Dash display when no latch sessions present
- Updated all existing test fixtures with new feed fields