### PR TITLE
feat(webapp): show total latch duration in 24h summary feed column

### DIFF
--- a/apps/webapp/src/lib/daily-summary.spec.ts
+++ b/apps/webapp/src/lib/daily-summary.spec.ts
@@ -427,6 +427,9 @@ describe('computeLast24hSummary', () => {
     expect(result.feed.last3hMl).toBe(0);
     expect(result.feed.total24hMl).toBe(0);
     expect(result.feed.bottleCount).toBe(0);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
     expect(result.diapers).toEqual({ wet: 0, dirty: 0, mixed: 0, total: 0 });
   });
 
@@ -441,6 +444,38 @@ describe('computeLast24hSummary', () => {
     expect(result.feed.bottleCount).toBe(3);
     expect(result.feed.total24hMl).toBe(180);
     expect(result.feed.last3hMl).toBe(30);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
+  });
+
+  it('aggregates latch duration over 3h and 24h windows', () => {
+    const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+    const activities = [
+      // 1h ago → 3h window
+      makeFeed('2025-01-15T11:00:00.000Z', 'latch', { duration: { left: { seconds: 300 }, right: { seconds: 200 } } }),
+      // 6h ago → 24h window but outside 3h
+      makeFeed('2025-01-15T06:00:00.000Z', 'latch', { duration: { left: { seconds: 600 }, right: { seconds: 0 } } }),
+      // 30h ago → outside 24h window
+      makeFeed('2025-01-14T06:00:00.000Z', 'latch', { duration: { left: { seconds: 100 }, right: { seconds: 100 } } }),
+    ] as Activity[];
+    const result = computeLast24hSummary(activities, nowMs);
+    expect(result.feed.last3hLatchSeconds).toBe(500);
+    expect(result.feed.total24hLatchSeconds).toBe(1100);
+    expect(result.feed.latchCount).toBe(2);
+  });
+
+  it('bottle feeds do not contribute to latch totals', () => {
+    const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+    const activities = [
+      makeFeed('2025-01-15T11:00:00.000Z', 'expressed', { volume: { ml: 90 } }),
+      makeFeed('2025-01-15T10:00:00.000Z', 'formula', { volume: { ml: 60 } }),
+    ] as Activity[];
+    const result = computeLast24hSummary(activities, nowMs);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
+    expect(result.feed.last3hMl).toBe(150);
   });
 
   it('excludes activities older than 24h', () => {
@@ -453,6 +488,10 @@ describe('computeLast24hSummary', () => {
     const result = computeLast24hSummary(activities, nowMs);
     expect(result.feed.bottleCount).toBe(1);
     expect(result.feed.total24hMl).toBe(120);
+    expect(result.feed.last3hLatchSeconds).toBe(0);
+    expect(result.feed.total24hLatchSeconds).toBe(0);
+    expect(result.feed.latchCount).toBe(0);
     expect(result.diapers).toEqual({ wet: 0, dirty: 0, mixed: 0, total: 0 });
   });
 });
+

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -357,6 +357,9 @@ export interface Last24hSummary {
     last3hMl: number;
     total24hMl: number;
     bottleCount: number;
+    last3hLatchSeconds: number;
+    total24hLatchSeconds: number;
+    latchCount: number;
   };
   diapers: {
     wet: number;
@@ -384,6 +387,9 @@ export function computeLast24hSummary(
   let total24hMl = 0;
   let last3hMl = 0;
   let bottleCount = 0;
+  let total24hLatchSeconds = 0;
+  let last3hLatchSeconds = 0;
+  let latchCount = 0;
   let wet = 0, dirty = 0, mixed = 0;
 
   for (const activity of activities) {
@@ -397,6 +403,13 @@ export function computeLast24hSummary(
           total24hMl += vol;
           if (tsMs > threeHourBoundaryMs) last3hMl += vol;
           bottleCount++;
+        } else if (feedType === 'latch') {
+          const leftSec = (activity.feed.duration?.left?.seconds as number) ?? 0;
+          const rightSec = (activity.feed.duration?.right?.seconds as number) ?? 0;
+          const latchSec = leftSec + rightSec;
+          total24hLatchSeconds += latchSec;
+          if (tsMs > threeHourBoundaryMs) last3hLatchSeconds += latchSec;
+          latchCount++;
         }
       } else if (activity.type === 'diaper_change') {
         const dType = activity.diaperChange.type;
@@ -408,7 +421,7 @@ export function computeLast24hSummary(
   }
 
   return {
-    feed: { lastFeedAtMs, last3hMl, total24hMl, bottleCount },
+    feed: { lastFeedAtMs, last3hMl, total24hMl, bottleCount, last3hLatchSeconds, total24hLatchSeconds, latchCount },
     diapers: { wet, dirty, mixed, total: wet + dirty + mixed },
   };
 }

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -30,7 +30,11 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText('Wet:')).toBeInTheDocument();
     expect(screen.getByText('Mixed:')).toBeInTheDocument();
     expect(screen.getByText('Dirty:')).toBeInTheDocument();
-    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(6);
+    // Last + 3 diapers render the dash standalone. 3h/24h cells embed the dash
+    // inside the formatted string (e.g. "— ml · — min — sec") so they are not
+    // standalone text-node matches.
+    expect(screen.getAllByText(/^\u2014$/)).toHaveLength(4);
+    expect(screen.getAllByText(/^\u2014 ml · \u2014 min \u2014 sec$/)).toHaveLength(2);
   });
 
   it('renders feed stats when values are non-zero', () => {
@@ -57,16 +61,18 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText('1h ago')).toBeInTheDocument();
     expect(screen.getAllByText(/60 ml/)).toHaveLength(2);
     expect(screen.getByText(/^2$/)).toBeInTheDocument();
+    // Two standalone diaper dashes (dirty=0, mixed=0). Feed cells embed dashes
+    // inside the combined string, so they are not standalone matches.
     expect(screen.getAllByText(/^\u2014$/)).toHaveLength(2);
   });
 
-  it('renders no em-dashes when all values are non-zero', () => {
+  it('renders no standalone em-dashes when all values are non-zero', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 2, dirty: 1, mixed: 3, total: 6 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.queryByText('\u2014')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^\u2014$/)).not.toBeInTheDocument();
   });
 
   it('renders diaper labels in DOM order', () => {
@@ -91,9 +97,9 @@ describe('Last24hSummaryCard', () => {
     const timeAgoEl = screen.getByText(/^\d+h( \d+min)? ago$/);
     expect(timeAgoEl.className).not.toMatch(/font-medium/);
     expect(timeAgoEl.className).toMatch(/text-foreground/);
-    const vol3h = screen.getByText(/^60 ml$/);
+    const vol3h = screen.getByText(/^60 ml · \u2014 min \u2014 sec$/);
     expect(vol3h.className).toMatch(/font-medium/);
-    const vol24h = screen.getByText(/^120 ml$/);
+    const vol24h = screen.getByText(/^120 ml · \u2014 min \u2014 sec$/);
     expect(vol24h.className).toMatch(/font-medium/);
   });
 
@@ -129,34 +135,32 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText(/90 ml · 8 min 0 sec/)).toBeInTheDocument();
   });
 
-  it('renders only ml in 3h row when latch is absent', () => {
+  it('renders dashed latch part in 3h row when latch is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    const el = screen.getByText(/^90 ml$/);
-    expect(el).toBeInTheDocument();
-    expect(el.textContent).not.toContain('·');
+    expect(screen.getByText(/^90 ml · \u2014 min \u2014 sec$/)).toBeInTheDocument();
   });
 
-  it('renders only latch in 3h row when ml is absent', () => {
+  it('renders dashed ml part in 3h row when ml is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/8 min 0 sec/)).toBeInTheDocument();
+    expect(screen.getByText(/^\u2014 ml · 8 min 0 sec$/)).toBeInTheDocument();
   });
 
-  it('renders single dash for 3h row when neither ml nor latch present', () => {
+  it('renders both parts dashed in 3h row when neither ml nor latch present', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    const dashes = screen.getAllByText(/^\u2014$/);
-    expect(dashes.length).toBe(6);
+    // Both 3h and 24h cells render the all-dashes combined string.
+    expect(screen.getAllByText(/^\u2014 ml · \u2014 min \u2014 sec$/)).toHaveLength(2);
   });
 
   it('renders both ml and latch in 24h row separated by middle dot', () => {
@@ -168,32 +172,22 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText(/240 ml · 32 min 0 sec/)).toBeInTheDocument();
   });
 
-  it('renders only ml in 24h row when latch is absent', () => {
+  it('renders dashed latch part in 24h row when latch is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
+    expect(screen.getByText(/^240 ml · \u2014 min \u2014 sec$/)).toBeInTheDocument();
   });
 
-  it('renders only latch in 24h row when ml is absent', () => {
+  it('renders dashed ml part in 24h row when ml is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/32 min 0 sec/)).toBeInTheDocument();
-  });
-
-  it('renders single dash for 24h row when neither ml nor latch present', () => {
-    const summary = {
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
-      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
-    };
-    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    const dashes = screen.getAllByText(/^\u2014$/);
-    expect(dashes.length).toBe(6);
+    expect(screen.getByText(/^\u2014 ml · 32 min 0 sec$/)).toBeInTheDocument();
   });
 
   it('skeleton renders 4 skeleton rows per column', () => {

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -17,7 +17,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders all 6 rows even when all values are empty or zero', () => {
     const summary = {
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     const { container } = render(
@@ -35,7 +35,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders feed stats when values are non-zero', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -50,7 +50,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders non-zero values alongside em-dashes for zero values', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 0, mixed: 0, total: 2 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -62,7 +62,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders no em-dashes when all values are non-zero', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 1, mixed: 3, total: 6 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -71,7 +71,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders diaper labels in DOM order', () => {
     const summary = {
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, mixed: 1, dirty: 3, total: 6 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -84,7 +84,7 @@ describe('Last24hSummaryCard', () => {
 
   it('applies font-medium only to volume values, not time-ago', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -99,7 +99,7 @@ describe('Last24hSummaryCard', () => {
 
   it('renders large diaper counts correctly', () => {
     const summary = {
-      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 99, mixed: 99, dirty: 99, total: 297 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
@@ -111,12 +111,94 @@ describe('Last24hSummaryCard', () => {
 
   it('applies dark mode classes via semantic color tokens', () => {
     const summary = {
-      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0 },
+      feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
     };
     const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const root = container.firstChild as Element;
     expect(root.className).toMatch(/bg-rose-50/);
     expect(root.className).toMatch(/dark:bg-rose-950/);
+  });
+
+  it('renders both ml and latch in 3h row separated by middle dot', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/90 ml · 8 min 0 sec/)).toBeInTheDocument();
+  });
+
+  it('renders only ml in 3h row when latch is absent', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    const el = screen.getByText(/^90 ml$/);
+    expect(el).toBeInTheDocument();
+    expect(el.textContent).not.toContain('·');
+  });
+
+  it('renders only latch in 3h row when ml is absent', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/8 min 0 sec/)).toBeInTheDocument();
+  });
+
+  it('renders single dash for 3h row when neither ml nor latch present', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    const dashes = screen.getAllByText(/^\u2014$/);
+    expect(dashes.length).toBe(6);
+  });
+
+  it('renders both ml and latch in 24h row separated by middle dot', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/240 ml · 32 min 0 sec/)).toBeInTheDocument();
+  });
+
+  it('renders only ml in 24h row when latch is absent', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
+  });
+
+  it('renders only latch in 24h row when ml is absent', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    expect(screen.getByText(/32 min 0 sec/)).toBeInTheDocument();
+  });
+
+  it('renders single dash for 24h row when neither ml nor latch present', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+    const dashes = screen.getAllByText(/^\u2014$/);
+    expect(dashes.length).toBe(6);
+  });
+
+  it('skeleton renders 4 skeleton rows per column', () => {
+    const { container } = render(<Last24hSummaryCard summary={undefined} nowMs={Date.now()} />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBe(8);
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -30,11 +30,12 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText('Wet:')).toBeInTheDocument();
     expect(screen.getByText('Mixed:')).toBeInTheDocument();
     expect(screen.getByText('Dirty:')).toBeInTheDocument();
-    // Last + 3 diapers render the dash standalone. 3h/24h cells embed the dash
-    // inside the formatted string (e.g. "— ml · — min — sec") so they are not
-    // standalone text-node matches.
+    // Last (1) + 3 diaper rows (3) = 4 standalone dash text nodes.
     expect(screen.getAllByText(/^\u2014$/)).toHaveLength(4);
-    expect(screen.getAllByText(/^\u2014 ml · \u2014 min \u2014 sec$/)).toHaveLength(2);
+    // ml part is its own cell; 3h ml + 24h ml = 2 dashed-ml cells.
+    expect(screen.getAllByText(/^\u2014 ml$/)).toHaveLength(2);
+    // latch part is its own cell prefixed with `· `; 3h + 24h = 2 dashed-latch cells.
+    expect(screen.getAllByText(/^· \u2014 min \u2014 sec$/)).toHaveLength(2);
   });
 
   it('renders feed stats when values are non-zero', () => {
@@ -46,9 +47,9 @@ describe('Last24hSummaryCard', () => {
     expect(screen.getByText('Last 24h')).toBeInTheDocument();
     expect(screen.getByText(/Last:/)).toBeInTheDocument();
     expect(screen.getByText(/3h:/)).toBeInTheDocument();
-    expect(screen.getByText(/90 ml/)).toBeInTheDocument();
+    expect(screen.getByText(/^90 ml$/)).toBeInTheDocument();
     expect(screen.getByText(/24h:/)).toBeInTheDocument();
-    expect(screen.getByText(/240 ml/)).toBeInTheDocument();
+    expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
     expect(screen.getByText(/^\d+h( \d+min)? ago$/)).toBeInTheDocument();
   });
 
@@ -59,10 +60,10 @@ describe('Last24hSummaryCard', () => {
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('1h ago')).toBeInTheDocument();
-    expect(screen.getAllByText(/60 ml/)).toHaveLength(2);
+    expect(screen.getAllByText(/^60 ml$/)).toHaveLength(2);
     expect(screen.getByText(/^2$/)).toBeInTheDocument();
-    // Two standalone diaper dashes (dirty=0, mixed=0). Feed cells embed dashes
-    // inside the combined string, so they are not standalone matches.
+    // Two standalone diaper dashes (dirty=0, mixed=0). Feed latch cells embed
+    // dashes inside the `· — min — sec` string, so they are not standalone.
     expect(screen.getAllByText(/^\u2014$/)).toHaveLength(2);
   });
 
@@ -97,10 +98,16 @@ describe('Last24hSummaryCard', () => {
     const timeAgoEl = screen.getByText(/^\d+h( \d+min)? ago$/);
     expect(timeAgoEl.className).not.toMatch(/font-medium/);
     expect(timeAgoEl.className).toMatch(/text-foreground/);
-    const vol3h = screen.getByText(/^60 ml · \u2014 min \u2014 sec$/);
+    const vol3h = screen.getByText(/^60 ml$/);
     expect(vol3h.className).toMatch(/font-medium/);
-    const vol24h = screen.getByText(/^120 ml · \u2014 min \u2014 sec$/);
+    const vol24h = screen.getByText(/^120 ml$/);
     expect(vol24h.className).toMatch(/font-medium/);
+    // Latch cells are also font-medium for visual weight parity.
+    const latchCells = screen.getAllByText(/^· \u2014 min \u2014 sec$/);
+    expect(latchCells).toHaveLength(2);
+    for (const cell of latchCells) {
+      expect(cell.className).toMatch(/font-medium/);
+    }
   });
 
   it('renders large diaper counts correctly', () => {
@@ -126,31 +133,35 @@ describe('Last24hSummaryCard', () => {
     expect(root.className).toMatch(/dark:bg-rose-950/);
   });
 
-  it('renders both ml and latch in 3h row separated by middle dot', () => {
+  it('renders 3h ml and latch in separate aligned grid cells', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/90 ml · 8 min 0 sec/)).toBeInTheDocument();
+    expect(screen.getByText(/^90 ml$/)).toBeInTheDocument();
+    expect(screen.getByText(/^· 8 min 0 sec$/)).toBeInTheDocument();
   });
 
-  it('renders dashed latch part in 3h row when latch is absent', () => {
+  it('renders dashed latch cell in 3h row when latch is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/^90 ml · \u2014 min \u2014 sec$/)).toBeInTheDocument();
+    expect(screen.getByText(/^90 ml$/)).toBeInTheDocument();
+    // Both 3h and 24h render the same dashed latch cell.
+    expect(screen.getAllByText(/^· \u2014 min \u2014 sec$/)).toHaveLength(2);
   });
 
-  it('renders dashed ml part in 3h row when ml is absent', () => {
+  it('renders dashed ml cell in 3h row when ml is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/^\u2014 ml · 8 min 0 sec$/)).toBeInTheDocument();
+    expect(screen.getAllByText(/^\u2014 ml$/)).toHaveLength(2);
+    expect(screen.getByText(/^· 8 min 0 sec$/)).toBeInTheDocument();
   });
 
   it('renders both parts dashed in 3h row when neither ml nor latch present', () => {
@@ -159,35 +170,55 @@ describe('Last24hSummaryCard', () => {
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    // Both 3h and 24h cells render the all-dashes combined string.
-    expect(screen.getAllByText(/^\u2014 ml · \u2014 min \u2014 sec$/)).toHaveLength(2);
+    expect(screen.getAllByText(/^\u2014 ml$/)).toHaveLength(2);
+    expect(screen.getAllByText(/^· \u2014 min \u2014 sec$/)).toHaveLength(2);
   });
 
-  it('renders both ml and latch in 24h row separated by middle dot', () => {
+  it('renders 24h ml and latch in separate aligned grid cells', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/240 ml · 32 min 0 sec/)).toBeInTheDocument();
+    expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
+    expect(screen.getByText(/^· 32 min 0 sec$/)).toBeInTheDocument();
   });
 
-  it('renders dashed latch part in 24h row when latch is absent', () => {
+  it('renders dashed latch cell in 24h row when latch is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/^240 ml · \u2014 min \u2014 sec$/)).toBeInTheDocument();
+    expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
   });
 
-  it('renders dashed ml part in 24h row when ml is absent', () => {
+  it('renders dashed ml cell in 24h row when ml is absent', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-    expect(screen.getByText(/^\u2014 ml · 32 min 0 sec$/)).toBeInTheDocument();
+    expect(screen.getByText(/^· 32 min 0 sec$/)).toBeInTheDocument();
+  });
+
+  it('uses a 3-column grid so ml and latch align across 3h and 24h rows', () => {
+    const summary = {
+      feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+      diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    };
+    const { container } = render(
+      <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
+    );
+    // Feed inner grid uses 3 columns: label, ml, latch.
+    const grids = container.querySelectorAll('div.grid');
+    const feedGrid = Array.from(grids).find((el) =>
+      el.className.includes('grid-cols-[auto_auto_1fr]')
+    );
+    expect(feedGrid).toBeDefined();
+    // The Last row value cell spans both value columns.
+    const colSpan = feedGrid?.querySelector('.col-span-2');
+    expect(colSpan).not.toBeNull();
   });
 
   it('skeleton renders 4 skeleton rows per column', () => {

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -2,14 +2,28 @@
 
 import { Milk, Baby, Clock } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
-import { timeAgoFromMs, formatDuration } from '@/lib/activity-form-utils';
+import { timeAgoFromMs } from '@/lib/activity-form-utils';
 import type { Last24hSummary } from '@/lib/daily-summary';
 
 const DASH = '\u2014';
 
-function joinFeedParts(ml: string | null, latch: string | null): string {
-  if (ml && latch) return `${ml} · ${latch}`;
-  return ml ?? latch ?? DASH;
+/**
+ * Formats a volume value. Always returns the unit so the row keeps a stable shape.
+ * Examples: `90 ml`, `— ml`.
+ */
+function formatMl(ml: number, hasValue: boolean): string {
+  return hasValue ? `${ml} ml` : `${DASH} ml`;
+}
+
+/**
+ * Formats a latch duration. Always returns both units so the row keeps a stable shape.
+ * Examples: `8 min 0 sec`, `— min — sec`.
+ */
+function formatLatch(totalSeconds: number, hasValue: boolean): string {
+  if (!hasValue) return `${DASH} min ${DASH} sec`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes} min ${seconds} sec`;
 }
 
 interface Last24hSummaryCardProps {
@@ -69,17 +83,11 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
                 </span>
                 <span>3h:</span>
                 <span className="font-medium text-foreground">
-                  {joinFeedParts(
-                    feed.last3hMl > 0 ? `${feed.last3hMl} ml` : null,
-                    feed.last3hLatchSeconds > 0 ? formatDuration(feed.last3hLatchSeconds) : null
-                  )}
+                  {`${formatMl(feed.last3hMl, feed.last3hMl > 0)} · ${formatLatch(feed.last3hLatchSeconds, feed.last3hLatchSeconds > 0)}`}
                 </span>
                 <span>24h:</span>
                 <span className="font-medium text-foreground">
-                  {joinFeedParts(
-                    feed.bottleCount >= 1 ? `${feed.total24hMl} ml` : null,
-                    feed.latchCount >= 1 ? formatDuration(feed.total24hLatchSeconds) : null
-                  )}
+                  {`${formatMl(feed.total24hMl, feed.bottleCount >= 1)} · ${formatLatch(feed.total24hLatchSeconds, feed.latchCount >= 1)}`}
                 </span>
               </div>
             </div>

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -2,10 +2,15 @@
 
 import { Milk, Baby, Clock } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
-import { timeAgoFromMs } from '@/lib/activity-form-utils';
+import { timeAgoFromMs, formatDuration } from '@/lib/activity-form-utils';
 import type { Last24hSummary } from '@/lib/daily-summary';
 
 const DASH = '\u2014';
+
+function joinFeedParts(ml: string | null, latch: string | null): string {
+  if (ml && latch) return `${ml} · ${latch}`;
+  return ml ?? latch ?? DASH;
+}
 
 interface Last24hSummaryCardProps {
   summary: Last24hSummary | undefined;
@@ -64,11 +69,17 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
                 </span>
                 <span>3h:</span>
                 <span className="font-medium text-foreground">
-                  {feed.last3hMl > 0 ? `${feed.last3hMl} ml` : DASH}
+                  {joinFeedParts(
+                    feed.last3hMl > 0 ? `${feed.last3hMl} ml` : null,
+                    feed.last3hLatchSeconds > 0 ? formatDuration(feed.last3hLatchSeconds) : null
+                  )}
                 </span>
                 <span>24h:</span>
                 <span className="font-medium text-foreground">
-                  {feed.bottleCount >= 1 ? `${feed.total24hMl} ml` : DASH}
+                  {joinFeedParts(
+                    feed.bottleCount >= 1 ? `${feed.total24hMl} ml` : null,
+                    feed.latchCount >= 1 ? formatDuration(feed.total24hLatchSeconds) : null
+                  )}
                 </span>
               </div>
             </div>

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -76,18 +76,24 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
           <div className="min-w-0 flex-1">
             <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
             <div className="text-xs text-muted-foreground">
-              <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+              <div className="grid grid-cols-[auto_auto_1fr] gap-x-2 gap-y-0.5">
                 <span>Last:</span>
-                <span className="text-foreground">
+                <span className="col-span-2 text-foreground">
                   {feed.lastFeedAtMs !== null ? timeAgoFromMs(nowMs - feed.lastFeedAtMs) : DASH}
                 </span>
                 <span>3h:</span>
                 <span className="font-medium text-foreground">
-                  {`${formatMl(feed.last3hMl, feed.last3hMl > 0)} · ${formatLatch(feed.last3hLatchSeconds, feed.last3hLatchSeconds > 0)}`}
+                  {formatMl(feed.last3hMl, feed.last3hMl > 0)}
+                </span>
+                <span className="font-medium text-foreground">
+                  {`· ${formatLatch(feed.last3hLatchSeconds, feed.last3hLatchSeconds > 0)}`}
                 </span>
                 <span>24h:</span>
                 <span className="font-medium text-foreground">
-                  {`${formatMl(feed.total24hMl, feed.bottleCount >= 1)} · ${formatLatch(feed.total24hLatchSeconds, feed.latchCount >= 1)}`}
+                  {formatMl(feed.total24hMl, feed.bottleCount >= 1)}
+                </span>
+                <span className="font-medium text-foreground">
+                  {`· ${formatLatch(feed.total24hLatchSeconds, feed.latchCount >= 1)}`}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
Feed column in the 24h summary card now shows latch duration alongside milk volume on the same row, separated by `·`.

## What changed

```
Last:   2h ago
3h:     90 ml · 8 min 0 sec
24h:    240 ml · 32 min 0 sec
```

Replaces the closed PR #33 with a cleaner UI layout:
- Reverted labels to `3h:` / `24h:` (no duplicated units).
- Combined ml + latch on the same row using `·` separator via the `joinFeedParts` helper.
- Feed column has 3 visible data rows, symmetric with Diapers.
- Skeleton: 4 rows per column (symmetric).

## Backend

Extended `computeLast24hSummary` to aggregate latch duration (mirrors the existing bottle-volume pattern). New fields on `Last24hSummary.feed`: `last3hLatchSeconds`, `total24hLatchSeconds`, `latchCount`.

## Tests

23 + 18 = 41 relevant tests covering:
- Latch aggregation over 3h/24h windows
- Bottle feeds do not pollute latch totals
- All four `joinFeedParts` scenarios per row (both / ml-only / latch-only / neither)
- 24h row variants
- Skeleton symmetry