### PR TITLE
feat(webapp): 3-col grid 24h summary + empty state polish

### DIFF
--- a/apps/webapp/src/app/app/page.test.tsx
+++ b/apps/webapp/src/app/app/page.test.tsx
@@ -86,7 +86,7 @@ describe('App home page', () => {
       };
       render(<AppHomePage />);
       await waitFor(() => {
-        expect(screen.getByText('No activities yet')).toBeInTheDocument();
+        expect(screen.getByText('Welcome!')).toBeInTheDocument();
       });
       expect(screen.getByText('Feed')).toBeInTheDocument();
     });

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -338,10 +338,16 @@ export default function AppHomePage() {
         <QuickActionGrid router={router} />
 
         <Card>
-          <CardContent className="flex flex-col items-center justify-center py-12">
-            <p className="text-muted-foreground text-lg">No activities yet</p>
-            <p className="text-muted-foreground text-sm mt-2">
-              Log your first activity using the buttons above.
+          <CardContent className="flex flex-col items-center justify-center py-16 text-center">
+            <div className="rounded-full bg-primary/10 p-6 mb-6">
+              <Baby className="h-12 w-12 text-primary" />
+            </div>
+            <h2 className="text-foreground text-xl font-semibold">Welcome!</h2>
+            <p className="text-muted-foreground text-sm mt-2 max-w-sm">
+              Track feedings, diaper changes, and medical events for your little one.
+            </p>
+            <p className="text-muted-foreground text-sm mt-1">
+              Tap a button above to log your first activity.
             </p>
           </CardContent>
         </Card>

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -205,7 +205,7 @@ describe('App home page', () => {
       render(<AppHomePage />);
 
       await waitFor(() => {
-        expect(screen.getByText(/no activities yet/i)).toBeInTheDocument();
+        expect(screen.getByText(/welcome!/i)).toBeInTheDocument();
       });
     });
 

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -41,8 +41,8 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
             Last 24h
           </span>
         </div>
-        <div className="grid grid-cols-2 gap-3 px-4 pb-2">
-          <div className="space-y-1.5">
+        <div className="grid grid-cols-3 gap-3 px-4 pb-2">
+          <div className="col-span-2 space-y-1.5">
             <Skeleton className="h-3 w-12" />
             <Skeleton className="h-3 w-full" />
             <Skeleton className="h-3 w-3/4" />
@@ -70,8 +70,8 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
         </span>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 px-4 pb-2">
-        <div className="flex items-start gap-2">
+      <div className="grid grid-cols-3 gap-3 px-4 pb-2">
+        <div className="col-span-2 flex items-start gap-2">
           <Milk className="h-3 w-3 text-rose-600 dark:text-rose-400 flex-shrink-0 mt-0.5" />
           <div className="min-w-0 flex-1">
             <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>


### PR DESCRIPTION
## Changes

**3-col grid layout for 24h summary** (8106d04)
- Switched Last24hSummaryCard to a 3-column grid with the feed/activity column spanning 2 columns
- Better use of horizontal space on desktop

**Empty state polish** (c56ad58)
- Replaced bland "No activities yet" text with a welcoming Baby icon + "Welcome!" heading
- Added description copy mentioning what the app tracks
- Styled with semantic Tailwind tokens for proper dark mode support

**Test updates** (9f8745b)
- Updated test assertions in `page.test.tsx` and `page.ui.spec.tsx` to match new empty state text

## Verification
- `pnpm typecheck` — clean (all packages)
- `pnpm test` — all 272 tests pass