### PR TITLE
feat(webapp): add Vitamin D recommendation tip and Vitamins tab

### DIFF
--- a/apps/mobile/__tests__/__mocks__/@workspace/domain/entities/Medical.ts
+++ b/apps/mobile/__tests__/__mocks__/@workspace/domain/entities/Medical.ts
@@ -1,6 +1,7 @@
 export enum MedicalType {
   Temperature = 'temperature',
   Medicine = 'medicine',
+  Vitamin = 'vitamin',
 }
 
-export type MedicalTypeLiteral = 'temperature' | 'medicine';
+export type MedicalTypeLiteral = 'temperature' | 'medicine' | 'vitamin';

--- a/apps/mobile/src/components/molecules/ActivityList/index.tsx
+++ b/apps/mobile/src/components/molecules/ActivityList/index.tsx
@@ -134,6 +134,11 @@ function ActivityItem(props: {
             subContent = `${medical.medicine.value} ${medical.medicine.unit}`;
             break;
           }
+          case 'vitamin': {
+            mainContent = `${medical.vitamin.name}`;
+            subContent = `${medical.vitamin.value} ${medical.vitamin.unit}`;
+            break;
+          }
         }
         break;
       }

--- a/apps/mobile/src/components/molecules/MedicalForm/MedicalForm.tsx
+++ b/apps/mobile/src/components/molecules/MedicalForm/MedicalForm.tsx
@@ -21,7 +21,7 @@ import { useMedicalFormStore } from '../../../storage/stores/medical-form-store'
 import { TextInput } from '../../atoms/TextInput/TextInput';
 
 // Define the types for medical activities
-type ActivityType = 'temperature' | 'medicine';
+type ActivityType = 'temperature' | 'medicine' | 'vitamin';
 
 type MedicalFormData =
   | {
@@ -31,6 +31,13 @@ type MedicalFormData =
     }
   | {
       type: 'medicine';
+      timestamp: DateTime;
+      name: string;
+      unit: string;
+      value: number;
+    }
+  | {
+      type: 'vitamin';
       timestamp: DateTime;
       name: string;
       unit: string;
@@ -63,6 +70,13 @@ const MedicalActivityForm = forwardRef<
     setMedicineName,
     setMedicineUnit,
     setMedicineValue,
+    // vitamin
+    vitaminName,
+    vitaminUnit,
+    vitaminValue,
+    setVitaminName,
+    setVitaminUnit,
+    setVitaminValue,
   } = useMedicalFormStore();
   const [date, setDate] = useState(new Date());
   const [isReady, setReady] = useState(false);
@@ -123,6 +137,20 @@ const MedicalActivityForm = forwardRef<
           });
           break;
         }
+        case 'vitamin': {
+          const val = parseFloat(vitaminValue);
+          if (isNaN(val)) {
+            Alert.alert('Invalid vitamin value');
+          }
+          onSubmit({
+            type: 'vitamin',
+            timestamp: DateTime.fromJSDate(date),
+            name: vitaminName,
+            unit: vitaminUnit,
+            value: val,
+          });
+          break;
+        }
       }
     } catch (err) {
       alert(err instanceof Error ? err.message : 'An error occurred');
@@ -138,6 +166,9 @@ const MedicalActivityForm = forwardRef<
     medicineName,
     medicineUnit,
     medicineValue,
+    vitaminName,
+    vitaminUnit,
+    vitaminValue,
   ]);
 
   useEffect(() => {
@@ -158,6 +189,7 @@ const MedicalActivityForm = forwardRef<
                 options={[
                   { value: 'temperature', label: 'Temperature' },
                   { value: 'medicine', label: 'Medicine' },
+                  { value: 'vitamin', label: 'Vitamins' },
                 ]}
                 value={medicalType}
                 onChange={(v) => setActivityType(v as ActivityType)}
@@ -193,7 +225,7 @@ const MedicalActivityForm = forwardRef<
                 <View className="border-r border-gray-400" />
                 <Text className="pl-2">°C</Text>
               </View>
-            ) : (
+            ) : medicalType === 'medicine' ? (
               <>
                 {/* Medicine Input */}
                 <View
@@ -233,6 +265,47 @@ const MedicalActivityForm = forwardRef<
                       ]}
                       value={medicineUnit}
                       onChange={setMedicineUnit}
+                    />
+                  </View>
+                </View>
+              </>
+            ) : (
+              <>
+                {/* Vitamin Input */}
+                <View
+                  className="mt-2 p-2 w-1/2 flex-row justify-center rounded-lg"
+                  style={{ backgroundColor: 'rgba(184, 207, 237, 255)' }}
+                >
+                  <TextInput
+                    className="flex-grow text-center"
+                    placeholder="Vitamin Name"
+                    value={vitaminName}
+                    onChangeText={setVitaminName}
+                    selectTextOnFocus={true}
+                  />
+                </View>
+                {/* Vitamin Value and Unit Input */}
+                <View
+                  className="mt-2 p-2 w-1/2 font-bold flex-row justify-center rounded-lg"
+                  style={{ backgroundColor: 'rgba(184, 207, 237, 255)' }}
+                >
+                  <TextInput
+                    className="text-center flex-1"
+                    keyboardType="numeric"
+                    placeholder="Value"
+                    value={vitaminValue}
+                    onChangeText={setVitaminValue}
+                    selectTextOnFocus={true}
+                  />
+                  <View className="border-r border-gray-400" />
+                  <View className="flex-grow flex-1">
+                    <SelectPicker
+                      options={[
+                        { value: 'drops', label: 'drops' },
+                        { value: 'ml', label: 'ml' },
+                      ]}
+                      value={vitaminUnit}
+                      onChange={setVitaminUnit}
                     />
                   </View>
                 </View>

--- a/apps/mobile/src/storage/stores/medical-form-store.tsx
+++ b/apps/mobile/src/storage/stores/medical-form-store.tsx
@@ -18,6 +18,13 @@ interface MedicalFormStoreState {
   setMedicineName: (v: string) => void;
   setMedicineValue: (v: string) => void;
   setMedicineUnit: (v: string) => void;
+  // vitamin
+  vitaminName: string;
+  vitaminValue: string;
+  vitaminUnit: string;
+  setVitaminName: (v: string) => void;
+  setVitaminValue: (v: string) => void;
+  setVitaminUnit: (v: string) => void;
   // others
   reset: () => void;
 }
@@ -29,6 +36,9 @@ const initialState: Pick<
   | 'medicineName'
   | 'medicineValue'
   | 'medicineUnit'
+  | 'vitaminName'
+  | 'vitaminValue'
+  | 'vitaminUnit'
 > = {
   medicalType: MedicalType.Temperature as MedicalType,
   // temperature
@@ -37,6 +47,10 @@ const initialState: Pick<
   medicineName: '' as string,
   medicineValue: '0' as string,
   medicineUnit: 'ml' as string,
+  // vitamin
+  vitaminName: 'Vitamin D' as string,
+  vitaminValue: '2' as string,
+  vitaminUnit: 'drops' as string,
 };
 
 export const useMedicalFormStore = create<MedicalFormStoreState>()(
@@ -55,6 +69,13 @@ export const useMedicalFormStore = create<MedicalFormStoreState>()(
       setMedicineName: (v: string) => set(() => ({ medicineName: v })),
       setMedicineValue: (v: string) => set(() => ({ medicineValue: v })),
       setMedicineUnit: (v: string) => set(() => ({ medicineUnit: v })),
+      // vitamin
+      vitaminName: 'Vitamin D' as string,
+      vitaminValue: '2' as string,
+      vitaminUnit: 'drops' as string,
+      setVitaminName: (v: string) => set(() => ({ vitaminName: v })),
+      setVitaminValue: (v: string) => set(() => ({ vitaminValue: v })),
+      setVitaminUnit: (v: string) => set(() => ({ vitaminUnit: v })),
       // others
       reset: () => set(() => ({ ...initialState })),
     }),

--- a/apps/webapp/src/app/app/medical/create/page.tsx
+++ b/apps/webapp/src/app/app/medical/create/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { Stethoscope, ChevronLeft } from 'lucide-react';
 import { useSessionMutation } from 'convex-helpers/react/sessions';
@@ -16,24 +16,29 @@ import { getDefaultDatetime, toTimestamp } from '@/lib/activity-form-utils';
 
 // ── Medical types ───────────────────────────────────────────────
 
-const MEDICAL_TYPES = ['temperature', 'medicine'] as const;
+const MEDICAL_TYPES = ['temperature', 'medicine', 'vitamin'] as const;
 type MedicalType = (typeof MEDICAL_TYPES)[number];
 
 const MEDICAL_LABELS: Record<MedicalType, string> = {
   temperature: 'Temperature',
   medicine: 'Medicine',
+  vitamin: 'Vitamins',
 };
 
 // ── Page Component ──────────────────────────────────────────────
 
 export default function MedicalCreatePage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const authState = useAuthState();
   const isAuthenticated = authState?.state === 'authenticated';
 
   const createActivity = useSessionMutation(api.web.babyTracker.activities.create);
 
-  const [medicalType, setMedicalType] = useState<MedicalType>('temperature');
+  const initialTab = searchParams.get('tab');
+  const isValidTab = initialTab === 'temperature' || initialTab === 'medicine' || initialTab === 'vitamin';
+
+  const [medicalType, setMedicalType] = useState<MedicalType>(isValidTab ? initialTab : 'temperature');
   const [datetime, setDatetime] = useState(getDefaultDatetime());
   const [saving, setSaving] = useState(false);
 
@@ -44,6 +49,11 @@ export default function MedicalCreatePage() {
   const [medName, setMedName] = useState('');
   const [medValue, setMedValue] = useState('');
   const [medUnit, setMedUnit] = useState('');
+
+  // Vitamin
+  const [vitaminName, setVitaminName] = useState('Vitamin D');
+  const [vitaminValue, setVitaminValue] = useState('2');
+  const [vitaminUnit, setVitaminUnit] = useState('drops');
 
   // Unauthenticated guard — after all hooks
   if (!isAuthenticated) {
@@ -61,13 +71,22 @@ export default function MedicalCreatePage() {
           type: 'temperature',
           temperature: { value: Number(tempValue) || 0 },
         };
-      } else {
+      } else if (medicalType === 'medicine') {
         medical = {
           type: 'medicine',
           medicine: {
             name: medName || '',
             value: Number(medValue) || 0,
             unit: medUnit || '',
+          },
+        };
+      } else {
+        medical = {
+          type: 'vitamin',
+          vitamin: {
+            name: vitaminName || '',
+            value: Number(vitaminValue) || 0,
+            unit: vitaminUnit || 'drops',
           },
         };
       }
@@ -181,6 +200,49 @@ export default function MedicalCreatePage() {
                       className="h-11"
                       value={medUnit}
                       onChange={(e) => setMedUnit(e.target.value)}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Vitamin fields */}
+            {medicalType === 'vitamin' && (
+              <div className="space-y-5">
+                <div className="space-y-1.5">
+                  <Label htmlFor="vitamin-name">Vitamin Name</Label>
+                  <Input
+                    id="vitamin-name"
+                    type="text"
+                    placeholder="e.g. Vitamin D"
+                    className="h-11"
+                    value={vitaminName}
+                    onChange={(e) => setVitaminName(e.target.value)}
+                  />
+                </div>
+                <div className="flex gap-3">
+                  <div className="space-y-1.5 flex-1">
+                    <Label htmlFor="vitamin-value">Drops</Label>
+                    <Input
+                      id="vitamin-value"
+                      type="number"
+                      min="0"
+                      step="1"
+                      placeholder="e.g. 2"
+                      className="h-11"
+                      value={vitaminValue}
+                      onChange={(e) => setVitaminValue(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1.5 flex-1">
+                    <Label htmlFor="vitamin-unit">Unit</Label>
+                    <Input
+                      id="vitamin-unit"
+                      type="text"
+                      placeholder="drops"
+                      className="h-11"
+                      value={vitaminUnit}
+                      onChange={(e) => setVitaminUnit(e.target.value)}
                     />
                   </div>
                 </div>

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
@@ -24,12 +24,13 @@ import { toLocalDatetimeString, toTimestamp } from '@/lib/activity-form-utils';
 
 // ── Medical types ───────────────────────────────────────────────
 
-const MEDICAL_TYPES = ['temperature', 'medicine'] as const;
+const MEDICAL_TYPES = ['temperature', 'medicine', 'vitamin'] as const;
 type MedicalType = (typeof MEDICAL_TYPES)[number];
 
 const MEDICAL_LABELS: Record<MedicalType, string> = {
   temperature: 'Temperature',
   medicine: 'Medicine',
+  vitamin: 'Vitamins',
 };
 
 // ── Page Component ──────────────────────────────────────────────
@@ -69,6 +70,11 @@ export default function MedicalEditPage() {
   const [medValue, setMedValue] = useState('');
   const [medUnit, setMedUnit] = useState('');
 
+  // Vitamin
+  const [vitaminName, setVitaminName] = useState('');
+  const [vitaminValue, setVitaminValue] = useState('');
+  const [vitaminUnit, setVitaminUnit] = useState('');
+
   // Pre-populate from loaded activity
   useEffect(() => {
     if (!activity || initialized) return;
@@ -88,6 +94,11 @@ export default function MedicalEditPage() {
       setMedName(medicine?.name ?? '');
       setMedValue(String(medicine?.value ?? ''));
       setMedUnit(medicine?.unit ?? '');
+    } else if (existingType === 'vitamin') {
+      const vitamin = med?.vitamin as { name: string; value: number; unit: string } | undefined;
+      setVitaminName(vitamin?.name ?? '');
+      setVitaminValue(String(vitamin?.value ?? ''));
+      setVitaminUnit(vitamin?.unit ?? '');
     }
 
     setInitialized(true);
@@ -146,13 +157,22 @@ export default function MedicalEditPage() {
           type: 'temperature',
           temperature: { value: Number(tempValue) || 0 },
         };
-      } else {
+      } else if (medicalType === 'medicine') {
         medical = {
           type: 'medicine',
           medicine: {
             name: medName || '',
             value: Number(medValue) || 0,
             unit: medUnit || '',
+          },
+        };
+      } else {
+        medical = {
+          type: 'vitamin',
+          vitamin: {
+            name: vitaminName || '',
+            value: Number(vitaminValue) || 0,
+            unit: vitaminUnit || 'drops',
           },
         };
       }
@@ -296,6 +316,49 @@ export default function MedicalEditPage() {
                       className="h-11"
                       value={medUnit}
                       onChange={(e) => setMedUnit(e.target.value)}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Vitamin fields */}
+            {medicalType === 'vitamin' && (
+              <div className="space-y-5">
+                <div className="space-y-1.5">
+                  <Label htmlFor="vitamin-name">Vitamin Name</Label>
+                  <Input
+                    id="vitamin-name"
+                    type="text"
+                    placeholder="e.g. Vitamin D"
+                    className="h-11"
+                    value={vitaminName}
+                    onChange={(e) => setVitaminName(e.target.value)}
+                  />
+                </div>
+                <div className="flex gap-3">
+                  <div className="space-y-1.5 flex-1">
+                    <Label htmlFor="vitamin-value">Drops</Label>
+                    <Input
+                      id="vitamin-value"
+                      type="number"
+                      min="0"
+                      step="1"
+                      placeholder="e.g. 2"
+                      className="h-11"
+                      value={vitaminValue}
+                      onChange={(e) => setVitaminValue(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1.5 flex-1">
+                    <Label htmlFor="vitamin-unit">Unit</Label>
+                    <Input
+                      id="vitamin-unit"
+                      type="text"
+                      placeholder="drops"
+                      className="h-11"
+                      value={vitaminUnit}
+                      onChange={(e) => setVitaminUnit(e.target.value)}
                     />
                   </div>
                 </div>

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -107,6 +107,19 @@ const ACTIVITY_ICON_MAP: Record<string, React.ComponentType<{ className?: string
   medical: Stethoscope,
 };
 
+function getIconBubbleClasses(activityType: string): { wrapper: string; icon: string } {
+  if (activityType === 'medical') {
+    return {
+      wrapper: 'bg-rose-100 dark:bg-rose-950/40',
+      icon: 'text-rose-600 dark:text-rose-400',
+    };
+  }
+  return {
+    wrapper: 'bg-muted',
+    icon: 'text-muted-foreground',
+  };
+}
+
 // ── Time-of-day grouping ───────────────────────────────────────
 
 export type TimeOfDay = 'midnight' | 'morning' | 'afternoon' | 'night';
@@ -404,6 +417,7 @@ export default function AppHomePage() {
                       const IconComponent = ACTIVITY_ICON_MAP[activity.type];
                       const isLastInGroup = idx === timeGroup.activities.length - 1;
                       const isLastOverall = isLastTimeGroup && isLastInGroup;
+                      const { wrapper: bubbleClass, icon: iconClass } = getIconBubbleClasses(activity.type);
 
                       return (
                         <Link
@@ -412,9 +426,9 @@ export default function AppHomePage() {
                           prefetch={true}
                           className={`w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-accent/50 transition-colors ${!isLastOverall ? 'border-b border-border' : ''}`}
                         >
-                          <span className="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-muted">
+                          <span className={`flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full ${bubbleClass}`}>
                             {IconComponent ? (
-                              <IconComponent className="h-5 w-5 text-muted-foreground" />
+                              <IconComponent className={`h-5 w-5 ${iconClass}`} />
                             ) : (
                               <span className="text-lg">📋</span>
                             )}

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -74,6 +74,11 @@ function getActivityDisplay(activity: ActivityItem): { label: string; sub: strin
           label: 'Medicine',
           sub: `${med.medicine.value} ${med.medicine.unit} ${med.medicine.name}`,
         };
+      case 'vitamin':
+        return {
+          label: 'Vitamin',
+          sub: `${med.vitamin.value} ${med.vitamin.unit} ${med.vitamin.name}`,
+        };
     }
   }
 

--- a/apps/webapp/src/app/app/page.tsx
+++ b/apps/webapp/src/app/app/page.tsx
@@ -232,6 +232,9 @@ export default function AppHomePage() {
     [results, nowMs]
   );
 
+  const family = useSessionQuery(api.web.babyTracker.family.get);
+  const vitaminDTipEnabled = family?.settings?.vitaminDTipEnabled;
+
   // ── Per-day summary computation ──────────────────────────────
   const dailySummariesByDay = useMemo(() => computeDailySummariesByDay(results), [results]);
 
@@ -361,7 +364,7 @@ export default function AppHomePage() {
       <QuickActionGrid router={router} />
 
       {/* Last 24h summary */}
-      <Last24hSummaryCard summary={last24h} nowMs={nowMs} />
+      <Last24hSummaryCard summary={last24h} nowMs={nowMs} vitaminDTipEnabled={vitaminDTipEnabled} />
 
       {/* Grouped activity list */}
       {groupedByDate.map((dateGroup) => {

--- a/apps/webapp/src/app/app/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/page.ui.spec.tsx
@@ -301,6 +301,38 @@ describe('App home page', () => {
       expect(screen.getByText('Medicine')).toBeInTheDocument();
       expect(screen.getByText(/5 ml Paracetamol/)).toBeInTheDocument();
     });
+
+    it('renders medical activity icon bubble with rose tint', () => {
+      // Supply only a temperature activity (medical) so the medical row is scoped tightly
+      mockRangeResults = [makeTemperatureActivity()];
+
+      render(<AppHomePage />);
+
+      const link = screen.getByText('Temperature').closest('a') as HTMLElement;
+      const bubble = link.querySelector('.rounded-full') as HTMLElement;
+      expect(bubble.className).toContain('bg-rose-100');
+      expect(bubble.className).toContain('dark:bg-rose-950/40');
+      const icon = bubble.querySelector('svg') as SVGElement;
+      const iconClass = icon.getAttribute('class') ?? '';
+      expect(iconClass).toContain('text-rose-600');
+      expect(iconClass).toContain('dark:text-rose-400');
+    });
+
+    it('renders non-medical activity icon bubble without rose tint', () => {
+      // Supply a feed activity (non-medical) — should have default muted classes
+      mockRangeResults = [makeLatchActivity()];
+
+      render(<AppHomePage />);
+
+      const link = screen.getByText('Latch Feed').closest('a') as HTMLElement;
+      const bubble = link.querySelector('.rounded-full') as HTMLElement;
+      expect(bubble.className).toContain('bg-muted');
+      expect(bubble.className).not.toContain('bg-rose-100');
+      const icon = bubble.querySelector('svg') as SVGElement;
+      const iconClass = icon.getAttribute('class') ?? '';
+      expect(iconClass).toContain('text-muted-foreground');
+      expect(iconClass).not.toContain('text-rose-600');
+    });
   });
 
   // ── 5. Date grouping ──────────────────────────────────────────

--- a/apps/webapp/src/app/app/settings/page.tsx
+++ b/apps/webapp/src/app/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { AccountCard } from '@/features/settings/components/AccountCard';
 import { FamilyCard } from '@/features/settings/components/FamilyCard';
+import { TipsCard } from '@/features/settings/components/TipsCard';
 import { useSettingsViewModel } from '@/features/settings/models/useSettingsViewModel';
 
 // ── Page Component ──────────────────────────────────────────────
@@ -86,6 +87,14 @@ export default function SettingsPage() {
         currentUserId={vm.currentUserId}
         onRemoveMember={vm.handleRemoveMember}
       />
+
+      {vm.inFamily && (
+        <TipsCard
+          vitaminDTipEnabled={vm.vitaminDTipEnabled}
+          onToggleVitaminDTip={vm.handleToggleVitaminDTip}
+          disabled={vm.togglingVitaminDTip}
+        />
+      )}
     </div>
   );
 }

--- a/apps/webapp/src/app/app/settings/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/settings/page.ui.spec.tsx
@@ -47,6 +47,7 @@ const mockInitUser = vi.fn().mockResolvedValue({ familyId: 'fam-new' });
 const mockRequestJoin = vi.fn().mockResolvedValue(undefined);
 const mockApproveJoin = vi.fn().mockResolvedValue(undefined);
 const mockLeaveFamily = vi.fn().mockResolvedValue(undefined);
+const mockSetVitaminDTipEnabled = vi.fn().mockResolvedValue({ enabled: false });
 
 // Track which mutation is requested — tests will configure
 let mockCreateMutation = mockInitUser;
@@ -470,6 +471,56 @@ describe('Settings page', () => {
 
       expect(screen.queryByText('Account')).not.toBeInTheDocument();
       expect(screen.queryByText('Family')).not.toBeInTheDocument();
+    });
+  });
+
+  // ── 6. TipsCard ───────────────────────────────────────────────
+
+  describe('Vitamin D tip toggle', () => {
+    beforeEach(() => {
+      mockIsLoading = false;
+      mockQueryResult = makeFamilyResult();
+    });
+
+    it('renders TipsCard when in a family', async () => {
+      render(<SettingsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Tips')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Vitamin D reminder')).toBeInTheDocument();
+      expect(screen.getByText(/Show a daily tip/)).toBeInTheDocument();
+    });
+
+    it('does not render TipsCard when not in a family', async () => {
+      mockQueryResult = null;
+      render(<SettingsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Account')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Tips')).not.toBeInTheDocument();
+    });
+
+    it('toggles the switch off and calls the mutation', async () => {
+      mockCreateMutation = mockSetVitaminDTipEnabled;
+      render(<SettingsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Vitamin D reminder')).toBeInTheDocument();
+      });
+
+      const switchEl = document.querySelector('[data-slot="switch"]');
+      expect(switchEl).toBeInTheDocument();
+      expect(switchEl).toHaveAttribute('data-state', 'checked');
+
+      await userEvent.click(switchEl!);
+
+      await waitFor(() => {
+        expect(mockSetVitaminDTipEnabled).toHaveBeenCalledWith(
+          expect.objectContaining({ enabled: false })
+        );
+      });
     });
   });
 });

--- a/apps/webapp/src/features/settings/components/TipsCard.tsx
+++ b/apps/webapp/src/features/settings/components/TipsCard.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Lightbulb } from 'lucide-react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+
+interface TipsCardProps {
+  vitaminDTipEnabled: boolean;
+  onToggleVitaminDTip: (next: boolean) => void;
+  disabled?: boolean;
+}
+
+export function TipsCard({ vitaminDTipEnabled, onToggleVitaminDTip, disabled }: TipsCardProps) {
+  return (
+    <Card>
+      <CardHeader className="px-4 pt-4 pb-3 sm:px-6 sm:pt-6">
+        <CardTitle className="flex items-center gap-2 text-base font-semibold">
+          <Lightbulb className="h-5 w-5" />
+          Tips
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-4 sm:px-6 sm:pb-6">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-foreground">Vitamin D reminder</p>
+            <p className="text-xs text-muted-foreground">
+              Show a daily tip on the dashboard when all feeds are breast milk
+            </p>
+          </div>
+          <Switch
+            checked={vitaminDTipEnabled}
+            onCheckedChange={onToggleVitaminDTip}
+            disabled={disabled}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/webapp/src/features/settings/models/useSettingsViewModel.ts
+++ b/apps/webapp/src/features/settings/models/useSettingsViewModel.ts
@@ -23,6 +23,7 @@ export interface FamilyData {
   _id: string;
   creatorId?: string;
   joinRequests?: JoinRequest[];
+  settings?: { vitaminDTipEnabled?: boolean };
   [key: string]: unknown;
 }
 
@@ -42,6 +43,10 @@ export interface SettingsViewModel {
   inFamily: boolean;
   /** True if the current user is the family creator. */
   isCreator: boolean;
+  /** Whether the Vitamin D dashboard tip is enabled (per-family setting). */
+  vitaminDTipEnabled: boolean;
+  /** True while the setVitaminDTipEnabled mutation is in-flight. */
+  togglingVitaminDTip: boolean;
 
   // ── Family join requests ────────────────────────────────
   /** Pending join requests for this family. */
@@ -104,6 +109,8 @@ export interface SettingsViewModel {
   handleRevokeInvite: (inviteId: string) => Promise<void>;
   /** Remove a member from the family. */
   handleRemoveMember: (memberUserId: string) => Promise<void>;
+  /** Toggle the Vitamin D dashboard tip for the family. */
+  handleToggleVitaminDTip: (next: boolean) => Promise<void>;
 }
 
 // ── Hook ────────────────────────────────────────────────────────
@@ -140,6 +147,7 @@ export function useSettingsViewModel(): SettingsViewModel {
   const createInvite = useSessionMutation(api.web.babyTracker.family.createInvite);
   const revokeInvite = useSessionMutation(api.web.babyTracker.family.revokeInvite);
   const removeMember = useSessionMutation(api.web.babyTracker.family.removeMember);
+  const setVitaminDTipEnabled = useSessionMutation(api.web.babyTracker.family.setVitaminDTipEnabled);
 
   // ── Local UI state ───────────────────────────────────────
   const [joinFamilyId, setJoinFamilyId] = useState('');
@@ -150,6 +158,7 @@ export function useSettingsViewModel(): SettingsViewModel {
   const [creatingInvite, setCreatingInvite] = useState(false);
   const [revokingId, setRevokingId] = useState<string | null>(null);
   const [removingId, setRemovingId] = useState<string | null>(null);
+  const [togglingVitaminDTip, setTogglingVitaminDTip] = useState(false);
 
   // ── Derived ─────────────────────────────────────────────
   const inFamily = !!family;
@@ -158,6 +167,7 @@ export function useSettingsViewModel(): SettingsViewModel {
   const isCreator = !!familyData?.creatorId && familyData.creatorId === userId;
   const joinRequests: JoinRequest[] = familyData?.joinRequests ?? [];
   const pendingRequests = joinRequests.filter((r) => r.status === 'pending');
+  const vitaminDTipEnabled = familyData?.settings?.vitaminDTipEnabled ?? true;
 
   // ── Actions ─────────────────────────────────────────────
 
@@ -256,6 +266,15 @@ export function useSettingsViewModel(): SettingsViewModel {
     }
   };
 
+  const handleToggleVitaminDTip = async (next: boolean) => {
+    setTogglingVitaminDTip(true);
+    try {
+      await setVitaminDTipEnabled({ enabled: next });
+    } finally {
+      setTogglingVitaminDTip(false);
+    }
+  };
+
   return {
     // Auth
     isAuthenticated,
@@ -266,6 +285,8 @@ export function useSettingsViewModel(): SettingsViewModel {
     family: familyData,
     inFamily,
     isCreator,
+    vitaminDTipEnabled,
+    togglingVitaminDTip,
 
     // Join requests
     pendingRequests,
@@ -302,5 +323,6 @@ export function useSettingsViewModel(): SettingsViewModel {
     handleCreateInvite,
     handleRevokeInvite,
     handleRemoveMember,
+    handleToggleVitaminDTip,
   };
 }

--- a/apps/webapp/src/lib/daily-summary.spec.ts
+++ b/apps/webapp/src/lib/daily-summary.spec.ts
@@ -36,6 +36,10 @@ function makeMedicine(ts: string, name: string, unit: string, value: number) {
   return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'medicine' as const, medicine: { name, unit, value } } };
 }
 
+function makeVitamin(ts: string, name: string) {
+  return { type: 'medical' as const, timestamp: Date.parse(ts), medical: { type: 'vitamin' as const, vitamin: { name } } };
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('computeDailySummary', () => {
@@ -492,6 +496,69 @@ describe('computeLast24hSummary', () => {
     expect(result.feed.total24hLatchSeconds).toBe(0);
     expect(result.feed.latchCount).toBe(0);
     expect(result.diapers).toEqual({ wet: 0, dirty: 0, mixed: 0, total: 0 });
+  });
+
+  describe('hasVitaminDInLast24h', () => {
+    it('is false when input is empty', () => {
+      const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+      const result = computeLast24hSummary([], nowMs);
+      expect(result.hasVitaminDInLast24h).toBe(false);
+    });
+
+    it('is true when a vitamin D entry is within the 24h window', () => {
+      const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+      const activities = [
+        makeVitamin('2025-01-15T08:00:00.000Z', 'Vitamin D'),
+      ] as Activity[];
+      const result = computeLast24hSummary(activities, nowMs);
+      expect(result.hasVitaminDInLast24h).toBe(true);
+    });
+
+    it('is false when a vitamin D entry is outside the 24h window', () => {
+      const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+      const activities = [
+        makeVitamin('2025-01-13T08:00:00.000Z', 'Vitamin D'),
+      ] as Activity[];
+      const result = computeLast24hSummary(activities, nowMs);
+      expect(result.hasVitaminDInLast24h).toBe(false);
+    });
+
+    it('matches "Vitamin D" case-insensitively', () => {
+      const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+      const activities = [
+        makeVitamin('2025-01-15T08:00:00.000Z', 'VITAMIN D'),
+      ] as Activity[];
+      const result = computeLast24hSummary(activities, nowMs);
+      expect(result.hasVitaminDInLast24h).toBe(true);
+    });
+
+    it('matches "vitamin d" (lowercase) case-insensitively', () => {
+      const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+      const activities = [
+        makeVitamin('2025-01-15T08:00:00.000Z', 'vitamin d'),
+      ] as Activity[];
+      const result = computeLast24hSummary(activities, nowMs);
+      expect(result.hasVitaminDInLast24h).toBe(true);
+    });
+
+    it('is false for non-D vitamins (e.g. "Vitamin C")', () => {
+      const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+      const activities = [
+        makeVitamin('2025-01-15T08:00:00.000Z', 'Vitamin C'),
+      ] as Activity[];
+      const result = computeLast24hSummary(activities, nowMs);
+      expect(result.hasVitaminDInLast24h).toBe(false);
+    });
+
+    it('is false for other medical types (temperature/medicine)', () => {
+      const nowMs = Date.parse('2025-01-15T12:00:00.000Z');
+      const activities = [
+        makeTemp('2025-01-15T08:00:00.000Z', 37.0),
+        makeMedicine('2025-01-15T09:00:00.000Z', 'Paracetamol', 'ml', 5),
+      ] as Activity[];
+      const result = computeLast24hSummary(activities, nowMs);
+      expect(result.hasVitaminDInLast24h).toBe(false);
+    });
   });
 });
 

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -42,6 +42,7 @@ interface MedicalActivity {
     type: MedicalSubType;
     temperature?: { value?: number };
     medicine?: { name?: string; unit?: string; value?: number };
+    vitamin?: { name?: string; value?: number; unit?: string };
   };
 }
 
@@ -368,6 +369,7 @@ export interface Last24hSummary {
     total: number;
   };
   allFeedsAreBreastMilk: boolean;
+  hasVitaminDInLast24h: boolean;
 }
 
 const BOTTLE_FEED_TYPES = ['expressed', 'formula', 'water'] as const;
@@ -394,6 +396,7 @@ export function computeLast24hSummary(
   let wet = 0, dirty = 0, mixed = 0;
   let feedCount24h = 0;
   let breastMilkFeedCount24h = 0;
+  let hasVitaminDInLast24h = false;
 
   for (const activity of activities) {
     const tsMs = activity.timestamp;
@@ -424,6 +427,13 @@ export function computeLast24hSummary(
         if (dType === 'wet') wet++;
         else if (dType === 'dirty') dirty++;
         else if (dType === 'mixed') mixed++;
+      } else if (activity.type === 'medical') {
+        if (activity.medical.type === 'vitamin') {
+          const name = activity.medical.vitamin?.name ?? '';
+          if (name.trim().toLowerCase() === 'vitamin d') {
+            hasVitaminDInLast24h = true;
+          }
+        }
       }
     }
   }
@@ -432,5 +442,6 @@ export function computeLast24hSummary(
     feed: { lastFeedAtMs, last3hMl, total24hMl, bottleCount, last3hLatchSeconds, total24hLatchSeconds, latchCount },
     diapers: { wet, dirty, mixed, total: wet + dirty + mixed },
     allFeedsAreBreastMilk: feedCount24h > 0 && feedCount24h === breastMilkFeedCount24h,
+    hasVitaminDInLast24h,
   };
 }

--- a/apps/webapp/src/lib/daily-summary.ts
+++ b/apps/webapp/src/lib/daily-summary.ts
@@ -13,7 +13,7 @@ import { DateTime } from 'luxon';
 
 type FeedSubType = 'latch' | 'expressed' | 'formula' | 'water' | 'solids';
 type DiaperSubType = 'wet' | 'dirty' | 'mixed';
-type MedicalSubType = 'temperature' | 'medicine';
+type MedicalSubType = 'temperature' | 'medicine' | 'vitamin';
 
 interface FeedActivity {
   type: 'feed';
@@ -367,6 +367,7 @@ export interface Last24hSummary {
     mixed: number;
     total: number;
   };
+  allFeedsAreBreastMilk: boolean;
 }
 
 const BOTTLE_FEED_TYPES = ['expressed', 'formula', 'water'] as const;
@@ -391,19 +392,26 @@ export function computeLast24hSummary(
   let last3hLatchSeconds = 0;
   let latchCount = 0;
   let wet = 0, dirty = 0, mixed = 0;
+  let feedCount24h = 0;
+  let breastMilkFeedCount24h = 0;
 
   for (const activity of activities) {
     const tsMs = activity.timestamp;
     if (tsMs <= nowMs && tsMs > windowStartMs) {
       if (activity.type === 'feed') {
+        feedCount24h++;
         if (tsMs > (lastFeedAtMs ?? 0)) lastFeedAtMs = tsMs;
         const feedType = activity.feed.type;
         if ((BOTTLE_FEED_TYPES as readonly string[]).includes(feedType)) {
+          if (feedType === 'expressed') {
+            breastMilkFeedCount24h++;
+          }
           const vol = (activity.feed as { type: BottleFeedSubType; volume?: { ml?: number } }).volume?.ml ?? 0;
           total24hMl += vol;
           if (tsMs > threeHourBoundaryMs) last3hMl += vol;
           bottleCount++;
         } else if (feedType === 'latch') {
+          breastMilkFeedCount24h++;
           const leftSec = (activity.feed.duration?.left?.seconds as number) ?? 0;
           const rightSec = (activity.feed.duration?.right?.seconds as number) ?? 0;
           const latchSec = leftSec + rightSec;
@@ -423,5 +431,6 @@ export function computeLast24hSummary(
   return {
     feed: { lastFeedAtMs, last3hMl, total24hMl, bottleCount, last3hLatchSeconds, total24hLatchSeconds, latchCount },
     diapers: { wet, dirty, mixed, total: wet + dirty + mixed },
+    allFeedsAreBreastMilk: feedCount24h > 0 && feedCount24h === breastMilkFeedCount24h,
   };
 }

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -44,6 +44,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     const { container } = render(
       <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
@@ -68,6 +69,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('Last 24h')).toBeInTheDocument();
@@ -84,6 +86,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 0, mixed: 0, total: 2 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('1h ago')).toBeInTheDocument();
@@ -99,6 +102,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 2, dirty: 1, mixed: 3, total: 6 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.queryByText(/^\u2014$/)).not.toBeInTheDocument();
@@ -109,6 +113,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, mixed: 1, dirty: 3, total: 6 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const labels = screen.getAllByText(/^(Wet|Mixed|Dirty):$/);
@@ -123,6 +128,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const timeAgoEl = screen.getByText(/^\d+h( \d+min)? ago$/);
@@ -145,6 +151,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 99, mixed: 99, dirty: 99, total: 297 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('Wet:')).toBeInTheDocument();
@@ -158,6 +165,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const root = container.firstChild as Element;
@@ -170,6 +178,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^90 ml$/)).toBeInTheDocument();
@@ -181,6 +190,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^90 ml$/)).toBeInTheDocument();
@@ -193,6 +203,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getAllByText(/^\u2014 ml$/)).toHaveLength(2);
@@ -204,6 +215,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getAllByText(/^\u2014 ml$/)).toHaveLength(2);
@@ -215,6 +227,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
@@ -226,6 +239,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
@@ -236,6 +250,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^· 32 min 0 sec$/)).toBeInTheDocument();
@@ -246,6 +261,7 @@ describe('Last24hSummaryCard', () => {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
     allFeedsAreBreastMilk: false,
+    hasVitaminDInLast24h: false,
     };
     const { container } = render(
       <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
@@ -265,5 +281,63 @@ describe('Last24hSummaryCard', () => {
     const { container } = render(<Last24hSummaryCard summary={undefined} nowMs={Date.now()} />);
     const skeletons = container.querySelectorAll('.animate-pulse');
     expect(skeletons.length).toBe(8);
+  });
+
+  describe('Vitamin D tip visibility', () => {
+    it('shows the Vitamin D tip when all conditions hold and setting is undefined', () => {
+      const summary = {
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+        allFeedsAreBreastMilk: true,
+        hasVitaminDInLast24h: false,
+      };
+      render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+      expect(screen.getByText(/Breast milk lacks Vitamin D/)).toBeInTheDocument();
+      expect(screen.getByText(/Log Vitamin D/)).toBeInTheDocument();
+    });
+
+    it('hides the tip when not all feeds are breast milk', () => {
+      const summary = {
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+        allFeedsAreBreastMilk: false,
+        hasVitaminDInLast24h: false,
+      };
+      render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+      expect(screen.queryByText(/Breast milk lacks Vitamin D/)).not.toBeInTheDocument();
+    });
+
+    it('hides the tip when vitamin D was logged in last 24h', () => {
+      const summary = {
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+        allFeedsAreBreastMilk: true,
+        hasVitaminDInLast24h: true,
+      };
+      render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+      expect(screen.queryByText(/Breast milk lacks Vitamin D/)).not.toBeInTheDocument();
+    });
+
+    it('hides the tip when family setting disables it', () => {
+      const summary = {
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+        allFeedsAreBreastMilk: true,
+        hasVitaminDInLast24h: false,
+      };
+      render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} vitaminDTipEnabled={false} />);
+      expect(screen.queryByText(/Breast milk lacks Vitamin D/)).not.toBeInTheDocument();
+    });
+
+    it('shows the tip when family setting explicitly enables it and other conditions hold', () => {
+      const summary = {
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+        allFeedsAreBreastMilk: true,
+        hasVitaminDInLast24h: false,
+      };
+      render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} vitaminDTipEnabled={true} />);
+      expect(screen.getByText(/Breast milk lacks Vitamin D/)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -2,6 +2,30 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Last24hSummaryCard } from './Last24hSummaryCard';
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  useSearchParams: () => ({
+    get: vi.fn().mockReturnValue(null),
+    getAll: vi.fn().mockReturnValue([]),
+    has: vi.fn().mockReturnValue(false),
+    forEach: vi.fn(),
+    entries: vi.fn().mockReturnValue([]),
+    keys: vi.fn().mockReturnValue([]),
+    values: vi.fn().mockReturnValue([]),
+    toString: vi.fn().mockReturnValue(''),
+    size: 0,
+  }),
+  usePathname: () => '/',
+  useParams: () => ({}),
+}));
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2025-01-15T12:00:00.000Z'));
@@ -19,6 +43,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     const { container } = render(
       <Last24hSummaryCard summary={summary} nowMs={Date.now()} />
@@ -42,6 +67,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 1, mixed: 0, total: 3 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('Last 24h')).toBeInTheDocument();
@@ -57,6 +83,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, dirty: 0, mixed: 0, total: 2 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('1h ago')).toBeInTheDocument();
@@ -71,6 +98,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 2, dirty: 1, mixed: 3, total: 6 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.queryByText(/^\u2014$/)).not.toBeInTheDocument();
@@ -80,6 +108,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 2, mixed: 1, dirty: 3, total: 6 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const labels = screen.getAllByText(/^(Wet|Mixed|Dirty):$/);
@@ -93,6 +122,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 120, bottleCount: 2, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const timeAgoEl = screen.getByText(/^\d+h( \d+min)? ago$/);
@@ -114,6 +144,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 99, mixed: 99, dirty: 99, total: 297 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText('Wet:')).toBeInTheDocument();
@@ -126,6 +157,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+    allFeedsAreBreastMilk: false,
     };
     const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const root = container.firstChild as Element;
@@ -137,6 +169,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^90 ml$/)).toBeInTheDocument();
@@ -147,6 +180,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^90 ml$/)).toBeInTheDocument();
@@ -158,6 +192,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getAllByText(/^\u2014 ml$/)).toHaveLength(2);
@@ -168,6 +203,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getAllByText(/^\u2014 ml$/)).toHaveLength(2);
@@ -178,6 +214,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
@@ -188,6 +225,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^240 ml$/)).toBeInTheDocument();
@@ -197,6 +235,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 0, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     expect(screen.getByText(/^· 32 min 0 sec$/)).toBeInTheDocument();
@@ -206,6 +245,7 @@ describe('Last24hSummaryCard', () => {
     const summary = {
       feed: { lastFeedAtMs: null, last3hMl: 90, total24hMl: 240, bottleCount: 3, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
       diapers: { wet: 0, dirty: 0, mixed: 0, total: 0 },
+    allFeedsAreBreastMilk: false,
     };
     const { container } = render(
       <Last24hSummaryCard summary={summary} nowMs={Date.now()} />

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -31,9 +31,10 @@ function formatLatch(totalSeconds: number, hasValue: boolean): string {
 interface Last24hSummaryCardProps {
   summary: Last24hSummary | undefined;
   nowMs: number;
+  vitaminDTipEnabled?: boolean;
 }
 
-export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) {
+export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last24hSummaryCardProps) {
   const router = useRouter();
 
   if (!summary) {
@@ -63,7 +64,8 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
     );
   }
 
-  const { feed, diapers, allFeedsAreBreastMilk } = summary;
+  const { feed, diapers, allFeedsAreBreastMilk, hasVitaminDInLast24h } = summary;
+  const showVitaminDTip = allFeedsAreBreastMilk && !hasVitaminDInLast24h && vitaminDTipEnabled !== false;
 
   return (
     <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
@@ -122,7 +124,7 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
         </div>
       </div>
 
-      {allFeedsAreBreastMilk && (
+      {showVitaminDTip && (
         <div className="mx-4 mb-2 p-3 flex items-center justify-between bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
           <div className="flex items-center gap-1.5">
             <Pill className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Milk, Baby, Clock } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Milk, Baby, Clock, Pill, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { timeAgoFromMs } from '@/lib/activity-form-utils';
 import type { Last24hSummary } from '@/lib/daily-summary';
@@ -32,6 +34,8 @@ interface Last24hSummaryCardProps {
 }
 
 export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) {
+  const router = useRouter();
+
   if (!summary) {
     return (
       <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
@@ -59,7 +63,7 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
     );
   }
 
-  const { feed, diapers } = summary;
+  const { feed, diapers, allFeedsAreBreastMilk } = summary;
 
   return (
     <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
@@ -117,6 +121,26 @@ export function Last24hSummaryCard({ summary, nowMs }: Last24hSummaryCardProps) 
           </div>
         </div>
       </div>
+
+      {allFeedsAreBreastMilk && (
+        <div className="mx-4 mb-2 p-3 flex items-center justify-between bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
+          <div className="flex items-center gap-1.5">
+            <Pill className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+            <span className="text-xs font-medium text-amber-900 dark:text-amber-200">
+              Breast milk lacks Vitamin D — consider supplements
+            </span>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-950/50 shrink-0 gap-1"
+            onClick={() => router.push('/app/medical/create?tab=vitamin')}
+          >
+            <span>Log Vitamin D</span>
+            <ArrowRight className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/core/domain/entities/Medical.ts
+++ b/core/domain/entities/Medical.ts
@@ -1,5 +1,6 @@
 export enum MedicalType {
   Temperature = 'temperature',
   Medicine = 'medicine',
+  Vitamin = 'vitamin',
 }
 export type MedicalTypeLiteral = `${MedicalType}`;

--- a/services/backend/convex/activities.ts
+++ b/services/backend/convex/activities.ts
@@ -48,6 +48,9 @@ export type Activity = {
   } | {
     type: 'medicine';
     medicine: { name: string; unit: string; value: number };
+  } | {
+    type: 'vitamin';
+    vitamin: { name: string; unit: string; value: number };
   };
   _id?: string;
 };
@@ -122,6 +125,14 @@ export const create = mutation({
           v.object({
             type: v.literal('medicine'),
             medicine: v.object({
+              name: v.string(),
+              unit: v.string(),
+              value: v.number(),
+            }),
+          }),
+          v.object({
+            type: v.literal('vitamin'),
+            vitamin: v.object({
               name: v.string(),
               unit: v.string(),
               value: v.number(),
@@ -201,6 +212,14 @@ export const update = mutation({
           v.object({
             type: v.literal('medicine'),
             medicine: v.object({
+              name: v.string(),
+              unit: v.string(),
+              value: v.number(),
+            }),
+          }),
+          v.object({
+            type: v.literal('vitamin'),
+            vitamin: v.object({
               name: v.string(),
               unit: v.string(),
               value: v.number(),

--- a/services/backend/convex/schema.ts
+++ b/services/backend/convex/schema.ts
@@ -76,6 +76,14 @@ export default defineSchema({
               unit: v.string(),
               value: v.number(),
             }),
+          }),
+          v.object({
+            type: v.literal('vitamin'),
+            vitamin: v.object({
+              name: v.string(),
+              unit: v.string(),
+              value: v.number(),
+            }),
           })
         ),
       })

--- a/services/backend/convex/schema.ts
+++ b/services/backend/convex/schema.ts
@@ -122,6 +122,11 @@ export default defineSchema({
         deviceId: v.string(), // DEPRECATED_DEVICE_SESSION
       })
     ),
+    settings: v.optional(
+      v.object({
+        vitaminDTipEnabled: v.optional(v.boolean()),
+      })
+    ),
   }),
 
   //TABLE: Family Join Requests

--- a/services/backend/convex/web/babyTracker/activities.ts
+++ b/services/backend/convex/web/babyTracker/activities.ts
@@ -79,6 +79,14 @@ const activityValidator = v.union(
           unit: v.string(),
           value: v.number(),
         }),
+      }),
+      v.object({
+        type: v.literal('vitamin'),
+        vitamin: v.object({
+          name: v.string(),
+          unit: v.string(),
+          value: v.number(),
+        }),
       })
     ),
   })

--- a/services/backend/convex/web/babyTracker/family.ts
+++ b/services/backend/convex/web/babyTracker/family.ts
@@ -215,6 +215,46 @@ export const switchFamily = mutation({
   },
 });
 
+/**
+ * Toggle the Vitamin D tip setting for the authenticated user's family.
+ * When disabled, the tip is hidden from the dashboard for all family members.
+ * Default (undefined) = enabled — families opt out explicitly.
+ */
+export const setVitaminDTipEnabled = mutation({
+  args: {
+    ...SessionIdArg,
+    enabled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const { userId } = await requireAuth(ctx, args.sessionId);
+
+    // Verify user is a member of a family
+    const membership = await ctx.db
+      .query('userFamily')
+      .withIndex('by_userId', (q) => q.eq('userId', userId))
+      .first();
+    if (!membership) {
+      throw new ConvexError({ code: 'FORBIDDEN', message: 'Not a family member' });
+    }
+
+    const family = await ctx.db.get(membership.familyId);
+    if (!family) {
+      throw new ConvexError({ code: 'NOT_FOUND', message: 'Family not found' });
+    }
+
+    // Preserve any existing settings fields while updating vitaminDTipEnabled
+    const existingSettings = family.settings ?? {};
+    await ctx.db.patch(membership.familyId, {
+      settings: {
+        ...existingSettings,
+        vitaminDTipEnabled: args.enabled,
+      },
+    });
+
+    return { enabled: args.enabled };
+  },
+});
+
 // ── Queries ────────────────────────────────────────────────────
 
 /**

--- a/services/backend/src/domain/activity/Activity.ts
+++ b/services/backend/src/domain/activity/Activity.ts
@@ -47,7 +47,12 @@ export interface MedicinePayload {
   medicine: { name: string; unit: string; value: number };
 }
 
-export type MedicalPayload = TemperaturePayload | MedicinePayload;
+export interface VitaminPayload {
+  type: 'vitamin';
+  vitamin: { name: string; unit: string; value: number };
+}
+
+export type MedicalPayload = TemperaturePayload | MedicinePayload | VitaminPayload;
 
 // ── Top-level activity union ────────────────────────────────────
 


### PR DESCRIPTION
## Problem
Breast milk (latch + expressed) lacks sufficient Vitamin D. When all feeds in the last 24h are breast milk only, parents should be prompted to supplement.

## What I did
- **Vitamin D tip**: When `allFeedsAreBreastMilk` is true for the last 24h, the Last24hSummaryCard shows an amber-tinted banner: "Breast milk lacks Vitamin D — consider supplements" with a "Log Vitamin D" button
- **Button navigates** to `/app/medical/create?tab=vitamin` which pre-selects the new Vitamins tab, defaulting to 2 drops
- **Vitamins tab** on both create and edit medical pages — fields: Vitamin Name, Drops (number), Unit
- **Added vitamin** as a medical sub-type across the full stack:
  - Domain entity, Convex schema, web validator, core MedicalType enum
  - Mobile MedicalForm, form store, ActivityList display
  - Home page activity display
- **`allFeedsAreBreastMilk`** computed in `computeLast24hSummary` — true when every feed in the 24h window is either latch or expressed (no formula, water, or solids)

## Files
- `services/backend/src/domain/activity/Activity.ts` — VitaminPayload
- `services/backend/convex/schema.ts` — vitamin union variant
- `services/backend/convex/web/babyTracker/activities.ts` — validator
- `core/domain/entities/Medical.ts` — Vitamin enum
- `apps/webapp/src/lib/daily-summary.ts` — allFeedsAreBreastMilk + MedicalSubType
- `apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx` — tip banner + button
- `apps/webapp/src/app/app/medical/create/page.tsx` — tab + query param + fields
- `apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx` — tab + fields
- `apps/webapp/src/app/app/page.tsx` — vitamin display
- `apps/mobile/...` — MedicalType mock, form store, MedicalForm, ActivityList

## Verification
- `pnpm typecheck` — clean
- `pnpm test` — all 272 tests pass (243 webapp + 20 backend + 9 mobile)
