### PR TITLE
feat(webapp): submit activity forms on Cmd+Enter

### DIFF
--- a/apps/webapp/src/app/app/diaper-change/create/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/create/page.tsx
@@ -12,6 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { getDefaultDatetime, toTimestamp } from '@/lib/activity-form-utils';
+import { useSubmitOnCmdEnter } from '@/hooks/useSubmitOnCmdEnter';
 
 // ── Diaper types ────────────────────────────────────────────────
 
@@ -37,11 +38,6 @@ export default function DiaperCreatePage() {
   const [remarks, setRemarks] = useState('');
   const [saving, setSaving] = useState(false);
 
-  // Unauthenticated guard — after all hooks
-  if (!isAuthenticated) {
-    return null;
-  }
-
   const handleSave = async () => {
     setSaving(true);
     try {
@@ -60,6 +56,13 @@ export default function DiaperCreatePage() {
       setSaving(false);
     }
   };
+
+  useSubmitOnCmdEnter({ onSubmit: handleSave, disabled: saving });
+
+  // Unauthenticated guard — after all hooks
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">

--- a/apps/webapp/src/app/app/diaper-change/create/page.ui.spec.tsx
+++ b/apps/webapp/src/app/app/diaper-change/create/page.ui.spec.tsx
@@ -214,6 +214,28 @@ describe('Diaper change create page', () => {
         expect(mockRouterPush).toHaveBeenCalledWith('/app');
       });
     });
+
+    it('calls create mutation on Cmd+Enter', async () => {
+      render(<DiaperCreatePage />);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      document.dispatchEvent(event);
+
+      await waitFor(() => {
+        expect(mockCreateActivity).toHaveBeenCalledWith({
+          activity: {
+            timestamp: expect.any(Number),
+            type: 'diaper_change',
+            diaperChange: { type: 'wet' },
+          },
+        });
+      });
+    });
   });
 
   // ── 5. Cancel navigation ──────────────────────────────────────

--- a/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/diaper-change/edit/[activityId]/page.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { toLocalDatetimeString, toTimestamp } from '@/lib/activity-form-utils';
+import { useSubmitOnCmdEnter } from '@/hooks/useSubmitOnCmdEnter';
 
 // ── Diaper types ────────────────────────────────────────────────
 
@@ -76,6 +77,38 @@ export default function DiaperEditPage() {
     setInitialized(true);
   }, [activity, initialized]);
 
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const timestamp = toTimestamp(datetime);
+
+      await updateActivity({
+        activityId,
+        activity: {
+          timestamp,
+          type: 'diaper_change',
+          diaperChange: { type: diaperType, remarks: remarks || undefined },
+        },
+      } as any);
+
+      router.push('/app');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await deleteActivity({ activityId } as any);
+      router.push('/app');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  useSubmitOnCmdEnter({ onSubmit: handleSave, disabled: saving });
+
   // Unauthenticated guard — after all hooks
   if (!isAuthenticated) {
     return null;
@@ -117,36 +150,6 @@ export default function DiaperEditPage() {
       </div>
     );
   }
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      const timestamp = toTimestamp(datetime);
-
-      await updateActivity({
-        activityId,
-        activity: {
-          timestamp,
-          type: 'diaper_change',
-          diaperChange: { type: diaperType, remarks: remarks || undefined },
-        },
-      } as any);
-
-      router.push('/app');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleDelete = async () => {
-    setDeleting(true);
-    try {
-      await deleteActivity({ activityId } as any);
-      router.push('/app');
-    } finally {
-      setDeleting(false);
-    }
-  };
 
   return (
     <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">

--- a/apps/webapp/src/app/app/feed/create/page.tsx
+++ b/apps/webapp/src/app/app/feed/create/page.tsx
@@ -15,6 +15,7 @@ import { useAuthState } from '@/modules/auth/AuthProvider';
 import { getDefaultDatetime, toSeconds, toMinutesSeconds, toTimestamp } from '@/lib/activity-form-utils';
 import { BreastTimer } from '@/components/BreastTimer';
 import { BREAST_TIMER_STORAGE_KEY } from '@/hooks/useBreastTimer';
+import { useSubmitOnCmdEnter } from '@/hooks/useSubmitOnCmdEnter';
 
 // ── Feed types ──────────────────────────────────────────────────
 
@@ -56,11 +57,6 @@ export default function FeedCreatePage() {
 
   // Submit state
   const [saving, setSaving] = useState(false);
-
-  // Unauthenticated guard — must be after all hooks
-  if (!isAuthenticated) {
-    return null;
-  }
 
   /** Build the activity payload and submit. */
   const handleSave = async () => {
@@ -115,6 +111,13 @@ export default function FeedCreatePage() {
       setSaving(false);
     }
   };
+
+  useSubmitOnCmdEnter({ onSubmit: handleSave, disabled: saving });
+
+  // Unauthenticated guard — must be after all hooks
+  if (!isAuthenticated) {
+    return null;
+  }
 
   // ── Render ──────────────────────────────────────────────────
 

--- a/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/feed/edit/[activityId]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { toSeconds, toMinutesSeconds, toLocalDatetimeString, toTimestamp } from '@/lib/activity-form-utils';
+import { useSubmitOnCmdEnter } from '@/hooks/useSubmitOnCmdEnter';
 
 // ── Feed types ──────────────────────────────────────────────────
 
@@ -112,48 +113,6 @@ export default function FeedEditPage() {
     setInitialized(true);
   }, [activity, initialized]);
 
-  // Unauthenticated guard — must be after all hooks
-  if (!isAuthenticated) {
-    return null;
-  }
-
-  // 404 — activity not found
-  if (isNotFound) {
-    return (
-      <div className="container mx-auto px-4 pt-8 max-w-xl flex flex-col items-center gap-4 text-center">
-        <p className="text-muted-foreground">Activity not found.</p>
-        <Button variant="outline" onClick={() => router.push('/app')}>
-          Go to Home
-        </Button>
-      </div>
-    );
-  }
-
-  // Loading state
-  if (!initialized) {
-    return (
-      <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">
-        <div className="flex items-center gap-2 mb-6">
-          <button
-            onClick={() => router.push('/app')}
-            className="p-2 -ml-2 rounded-full hover:bg-accent transition-colors"
-            aria-label="Back"
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-          <Milk className="h-6 w-6 text-blue-600 dark:text-blue-400" />
-          <h1 className="text-xl font-bold">Edit Feed</h1>
-        </div>
-        <div className="space-y-4">
-          <Skeleton className="h-12 w-full" />
-          <Skeleton className="h-40 w-full" />
-          <Skeleton className="h-12 w-full" />
-        </div>
-        <p className="text-center text-muted-foreground mt-4">Loading...</p>
-      </div>
-    );
-  }
-
   // ── Handlers ─────────────────────────────────────────────────
 
   const handleSave = async () => {
@@ -214,6 +173,50 @@ export default function FeedEditPage() {
       setDeleting(false);
     }
   };
+
+  useSubmitOnCmdEnter({ onSubmit: handleSave, disabled: saving });
+
+  // Unauthenticated guard — must be after all hooks
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  // 404 — activity not found
+  if (isNotFound) {
+    return (
+      <div className="container mx-auto px-4 pt-8 max-w-xl flex flex-col items-center gap-4 text-center">
+        <p className="text-muted-foreground">Activity not found.</p>
+        <Button variant="outline" onClick={() => router.push('/app')}>
+          Go to Home
+        </Button>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (!initialized) {
+    return (
+      <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">
+        <div className="flex items-center gap-2 mb-6">
+          <button
+            onClick={() => router.push('/app')}
+            className="p-2 -ml-2 rounded-full hover:bg-accent transition-colors"
+            aria-label="Back"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+          <Milk className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+          <h1 className="text-xl font-bold">Edit Feed</h1>
+        </div>
+        <div className="space-y-4">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+        <p className="text-center text-muted-foreground mt-4">Loading...</p>
+      </div>
+    );
+  }
 
   // ── Render ──────────────────────────────────────────────────
 

--- a/apps/webapp/src/app/app/medical/create/page.tsx
+++ b/apps/webapp/src/app/app/medical/create/page.tsx
@@ -13,6 +13,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { getDefaultDatetime, toTimestamp } from '@/lib/activity-form-utils';
+import { useSubmitOnCmdEnter } from '@/hooks/useSubmitOnCmdEnter';
 
 // ── Medical types ───────────────────────────────────────────────
 
@@ -54,11 +55,6 @@ export default function MedicalCreatePage() {
   const [vitaminName, setVitaminName] = useState('Vitamin D');
   const [vitaminValue, setVitaminValue] = useState('2');
   const [vitaminUnit, setVitaminUnit] = useState('drops');
-
-  // Unauthenticated guard — after all hooks
-  if (!isAuthenticated) {
-    return null;
-  }
 
   const handleSave = async () => {
     setSaving(true);
@@ -104,6 +100,13 @@ export default function MedicalCreatePage() {
       setSaving(false);
     }
   };
+
+  useSubmitOnCmdEnter({ onSubmit: handleSave, disabled: saving });
+
+  // Unauthenticated guard — after all hooks
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">

--- a/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
+++ b/apps/webapp/src/app/app/medical/edit/[activityId]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useAuthState } from '@/modules/auth/AuthProvider';
 import { toLocalDatetimeString, toTimestamp } from '@/lib/activity-form-utils';
+import { useSubmitOnCmdEnter } from '@/hooks/useSubmitOnCmdEnter';
 
 // ── Medical types ───────────────────────────────────────────────
 
@@ -104,48 +105,6 @@ export default function MedicalEditPage() {
     setInitialized(true);
   }, [activity, initialized]);
 
-  // Unauthenticated guard — after all hooks
-  if (!isAuthenticated) {
-    return null;
-  }
-
-  // 404 — activity not found
-  if (isNotFound) {
-    return (
-      <div className="container mx-auto px-4 pt-8 max-w-xl flex flex-col items-center gap-4 text-center">
-        <p className="text-muted-foreground">Activity not found.</p>
-        <Button variant="outline" onClick={() => router.push('/app')}>
-          Go to Home
-        </Button>
-      </div>
-    );
-  }
-
-  // Loading state
-  if (!initialized) {
-    return (
-      <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">
-        <div className="flex items-center gap-2 mb-6">
-          <button
-            onClick={() => router.push('/app')}
-            className="p-2 -ml-2 rounded-full hover:bg-accent transition-colors"
-            aria-label="Back"
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-          <Stethoscope className="h-6 w-6 text-rose-600 dark:text-rose-400" />
-          <h1 className="text-xl font-bold">Edit Medical</h1>
-        </div>
-        <div className="space-y-4">
-          <Skeleton className="h-12 w-full" />
-          <Skeleton className="h-32 w-full" />
-          <Skeleton className="h-12 w-full" />
-        </div>
-        <p className="text-center text-muted-foreground mt-4">Loading...</p>
-      </div>
-    );
-  }
-
   const handleSave = async () => {
     setSaving(true);
     try {
@@ -201,6 +160,50 @@ export default function MedicalEditPage() {
       setDeleting(false);
     }
   };
+
+  useSubmitOnCmdEnter({ onSubmit: handleSave, disabled: saving });
+
+  // Unauthenticated guard — after all hooks
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  // 404 — activity not found
+  if (isNotFound) {
+    return (
+      <div className="container mx-auto px-4 pt-8 max-w-xl flex flex-col items-center gap-4 text-center">
+        <p className="text-muted-foreground">Activity not found.</p>
+        <Button variant="outline" onClick={() => router.push('/app')}>
+          Go to Home
+        </Button>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (!initialized) {
+    return (
+      <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">
+        <div className="flex items-center gap-2 mb-6">
+          <button
+            onClick={() => router.push('/app')}
+            className="p-2 -ml-2 rounded-full hover:bg-accent transition-colors"
+            aria-label="Back"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+          <Stethoscope className="h-6 w-6 text-rose-600 dark:text-rose-400" />
+          <h1 className="text-xl font-bold">Edit Medical</h1>
+        </div>
+        <div className="space-y-4">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+        <p className="text-center text-muted-foreground mt-4">Loading...</p>
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto px-4 pt-4 pb-8 max-w-xl">

--- a/apps/webapp/src/hooks/useSubmitOnCmdEnter.spec.ts
+++ b/apps/webapp/src/hooks/useSubmitOnCmdEnter.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSubmitOnCmdEnter } from './useSubmitOnCmdEnter';
+
+function dispatchKeyDown(init: KeyboardEventInit) {
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe('useSubmitOnCmdEnter', () => {
+  it('fires onSubmit on Cmd+Enter (metaKey)', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useSubmitOnCmdEnter({ onSubmit }));
+
+    const event = dispatchKeyDown({ key: 'Enter', metaKey: true });
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('fires onSubmit on Ctrl+Enter (ctrlKey)', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useSubmitOnCmdEnter({ onSubmit }));
+
+    const event = dispatchKeyDown({ key: 'Enter', ctrlKey: true });
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does NOT fire on plain Enter (no modifier)', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useSubmitOnCmdEnter({ onSubmit }));
+
+    const event = dispatchKeyDown({ key: 'Enter' });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('does NOT fire on Cmd+Other key', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useSubmitOnCmdEnter({ onSubmit }));
+
+    const event = dispatchKeyDown({ key: 's', metaKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('does NOT fire when disabled', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useSubmitOnCmdEnter({ onSubmit, disabled: true }));
+
+    const event = dispatchKeyDown({ key: 'Enter', metaKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('does NOT fire while composing (IME)', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useSubmitOnCmdEnter({ onSubmit }));
+
+    dispatchKeyDown({ key: 'Enter', metaKey: true, isComposing: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('unmount removes the listener', () => {
+    const onSubmit = vi.fn();
+    const { unmount } = renderHook(() => useSubmitOnCmdEnter({ onSubmit }));
+
+    unmount();
+
+    dispatchKeyDown({ key: 'Enter', metaKey: true });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('uses latest onSubmit and disabled between renders', () => {
+    const firstOnSubmit = vi.fn();
+    const secondOnSubmit = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ onSubmit, disabled }) => useSubmitOnCmdEnter({ onSubmit, disabled }),
+      { initialProps: { onSubmit: firstOnSubmit, disabled: true } },
+    );
+
+    // Disabled — shouldn't fire
+    dispatchKeyDown({ key: 'Enter', metaKey: true });
+    expect(firstOnSubmit).not.toHaveBeenCalled();
+
+    // Re-render with new onSubmit and disabled=false
+    rerender({ onSubmit: secondOnSubmit, disabled: false });
+
+    dispatchKeyDown({ key: 'Enter', metaKey: true });
+    expect(firstOnSubmit).not.toHaveBeenCalled();
+    expect(secondOnSubmit).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/webapp/src/hooks/useSubmitOnCmdEnter.ts
+++ b/apps/webapp/src/hooks/useSubmitOnCmdEnter.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type UseSubmitOnCmdEnterOptions = {
+  onSubmit: () => void | Promise<void>;
+  disabled?: boolean;
+};
+
+export function useSubmitOnCmdEnter({
+  onSubmit,
+  disabled,
+}: UseSubmitOnCmdEnterOptions): void {
+  const onSubmitRef = useRef(onSubmit);
+  const disabledRef = useRef(disabled);
+
+  onSubmitRef.current = onSubmit;
+  disabledRef.current = disabled;
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (
+        e.key === 'Enter' &&
+        (e.metaKey || e.ctrlKey) &&
+        e.isComposing === false &&
+        !disabledRef.current
+      ) {
+        e.preventDefault();
+        void onSubmitRef.current();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+}


### PR DESCRIPTION
## Problem
Logging an activity requires reaching for the mouse to hit Save. Keyboard-heavy users want a quick shortcut.

## What I did
- Added a reusable `useSubmitOnCmdEnter({ onSubmit, disabled })` hook (`apps/webapp/src/hooks/useSubmitOnCmdEnter.ts`)
- Hook fires on `(metaKey || ctrlKey) + Enter`, ignores plain Enter (textareas keep newline behaviour), ignores IME composition, respects a disabled flag, cleans up on unmount, and uses a ref so the latest `onSubmit` is always called without re-attaching the listener
- Wired the hook into all 6 activity create/edit pages (feed/diaper-change/medical × create/edit) using each page's existing `handleSave` + `saving` state — no other refactoring beyond hoisting handlers above early-return branches to satisfy React's Rules of Hooks
- Added 8 hook unit tests + 1 page-level integration test (`diaper-change/create`) confirming Cmd+Enter triggers the save mutation

## Verification
- `pnpm typecheck` clean
- `pnpm test` clean (269 tests passing)

Closes backlog item `ps7cvak0ka2r7dbwd8yh737zhx87cj05`.