### PR TITLE
feat(webapp): rewrite Vitamin D tip as a structured notice

### DIFF
--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Last24hSummaryCard } from './Last24hSummaryCard';
 
 vi.mock('next/navigation', () => ({
@@ -284,7 +284,7 @@ describe('Last24hSummaryCard', () => {
   });
 
   describe('Vitamin D tip visibility', () => {
-    it('shows the Vitamin D tip when all conditions hold and setting is undefined', () => {
+    it('shows expander button when all conditions hold and setting is undefined', () => {
       const summary = {
         feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
         diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
@@ -292,12 +292,21 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+
+      const expander = screen.getByRole('button', { name: '1 recommendation available' });
+      expect(expander).toBeInTheDocument();
+      expect(expander).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
+
+      fireEvent.click(expander);
+
+      expect(expander).toHaveAttribute('aria-expanded', 'true');
       expect(screen.getByText(/Consider a Vitamin D supplement/)).toBeInTheDocument();
       expect(screen.getByText(/Log Vitamin D now/)).toBeInTheDocument();
       expect(screen.getByText(/Exclusively breastfed babies don't get enough Vitamin D/)).toBeInTheDocument();
     });
 
-    it('hides the tip when not all feeds are breast milk', () => {
+    it('hides expander when not all feeds are breast milk', () => {
       const summary = {
         feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 60, total24hMl: 60, bottleCount: 1, last3hLatchSeconds: 0, total24hLatchSeconds: 0, latchCount: 0 },
         diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
@@ -305,10 +314,10 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /recommendation/i })).not.toBeInTheDocument();
     });
 
-    it('hides the tip when vitamin D was logged in last 24h', () => {
+    it('hides expander when vitamin D was logged in last 24h', () => {
       const summary = {
         feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
         diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
@@ -316,10 +325,10 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: true,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /recommendation/i })).not.toBeInTheDocument();
     });
 
-    it('hides the tip when family setting disables it', () => {
+    it('hides expander when family setting disables it', () => {
       const summary = {
         feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
         diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
@@ -327,10 +336,10 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} vitaminDTipEnabled={false} />);
-      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /recommendation/i })).not.toBeInTheDocument();
     });
 
-    it('shows the tip when family setting explicitly enables it and other conditions hold', () => {
+    it('shows expander when family setting explicitly enables it and other conditions hold', () => {
       const summary = {
         feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
         diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
@@ -338,7 +347,41 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} vitaminDTipEnabled={true} />);
+
+      const expander = screen.getByRole('button', { name: '1 recommendation available' });
+      expect(expander).toBeInTheDocument();
+
+      fireEvent.click(expander);
       expect(screen.getByText(/Consider a Vitamin D supplement/)).toBeInTheDocument();
+    });
+
+    it('collapses again when expander is clicked twice', () => {
+      const summary = {
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+        allFeedsAreBreastMilk: true,
+        hasVitaminDInLast24h: false,
+      };
+      render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+
+      const expander = screen.getByRole('button', { name: '1 recommendation available' });
+
+      fireEvent.click(expander);
+      expect(screen.getByText(/Consider a Vitamin D supplement/)).toBeInTheDocument();
+
+      fireEvent.click(expander);
+      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
+    });
+
+    it('button label uses singular form', () => {
+      const summary = {
+        feed: { lastFeedAtMs: Date.now() - 3_600_000, last3hMl: 0, total24hMl: 0, bottleCount: 0, last3hLatchSeconds: 480, total24hLatchSeconds: 1920, latchCount: 4 },
+        diapers: { wet: 1, dirty: 0, mixed: 0, total: 1 },
+        allFeedsAreBreastMilk: true,
+        hasVitaminDInLast24h: false,
+      };
+      render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
+      expect(screen.getByRole('button', { name: '1 recommendation available' })).toBeInTheDocument();
     });
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -169,8 +169,8 @@ describe('Last24hSummaryCard', () => {
     };
     const { container } = render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
     const root = container.firstChild as Element;
-    expect(root.className).toMatch(/bg-rose-50/);
-    expect(root.className).toMatch(/dark:bg-rose-950/);
+    expect(root.className).toMatch(/bg-blue-50/);
+    expect(root.className).toMatch(/dark:bg-blue-950/);
   });
 
   it('renders 3h ml and latch in separate aligned grid cells', () => {

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -292,8 +292,9 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-      expect(screen.getByText(/Breast milk lacks Vitamin D/)).toBeInTheDocument();
-      expect(screen.getByText(/Log Vitamin D/)).toBeInTheDocument();
+      expect(screen.getByText(/Consider a Vitamin D supplement/)).toBeInTheDocument();
+      expect(screen.getByText(/Log Vitamin D now/)).toBeInTheDocument();
+      expect(screen.getByText(/Exclusively breastfed babies don't get enough Vitamin D/)).toBeInTheDocument();
     });
 
     it('hides the tip when not all feeds are breast milk', () => {
@@ -304,7 +305,7 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-      expect(screen.queryByText(/Breast milk lacks Vitamin D/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
     });
 
     it('hides the tip when vitamin D was logged in last 24h', () => {
@@ -315,7 +316,7 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: true,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-      expect(screen.queryByText(/Breast milk lacks Vitamin D/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
     });
 
     it('hides the tip when family setting disables it', () => {
@@ -326,7 +327,7 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} vitaminDTipEnabled={false} />);
-      expect(screen.queryByText(/Breast milk lacks Vitamin D/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
     });
 
     it('shows the tip when family setting explicitly enables it and other conditions hold', () => {
@@ -337,7 +338,7 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} vitaminDTipEnabled={true} />);
-      expect(screen.getByText(/Breast milk lacks Vitamin D/)).toBeInTheDocument();
+      expect(screen.getByText(/Consider a Vitamin D supplement/)).toBeInTheDocument();
     });
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -69,20 +69,20 @@ function RecommendationCard({
   onCtaClick: () => void;
 }) {
   return (
-    <div className="p-3 flex flex-col gap-2.5 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-md">
+    <div className="p-3 flex flex-col gap-2.5 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
       <div className="flex items-center gap-2">
-        <Pill className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0" />
-        <h3 className="text-sm font-semibold text-red-900 dark:text-red-100">
+        <Pill className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
+        <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-100">
           {rec.title}
         </h3>
       </div>
-      <p className="text-xs leading-relaxed text-red-900/85 dark:text-red-200/85">
+      <p className="text-xs leading-relaxed text-amber-900/85 dark:text-amber-200/85">
         {rec.body}
       </p>
       <Button
         variant="outline"
         size="sm"
-        className="w-full h-8 text-xs border-red-300 dark:border-red-700 text-red-800 dark:text-red-200 hover:bg-red-100 dark:hover:bg-red-950/50 gap-1.5"
+        className="w-full h-8 text-xs border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-950/50 gap-1.5"
         onClick={onCtaClick}
       >
         <span>{rec.ctaLabel}</span>
@@ -184,11 +184,11 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
       </div>
 
       {recommendations.length > 0 && (
-        <div className="border-t border-blue-200 dark:border-blue-900">
+        <div className="border-t border-red-200 dark:border-red-900">
           <button
             type="button"
             onClick={() => setIsExpanded((v) => !v)}
-            className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-blue-900 dark:text-blue-200 hover:bg-blue-100/60 dark:hover:bg-blue-950/40 transition-colors"
+            className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
             aria-expanded={isExpanded}
             aria-controls="last24h-recommendations-list"
           >

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -97,10 +97,10 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
 
   if (!summary) {
     return (
-      <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
+      <div className="bg-blue-50/60 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-900 rounded-lg mb-6">
         <div className="flex items-center gap-1.5 px-4 pt-2 pb-1">
-          <Clock className="h-3.5 w-3.5 text-rose-600 dark:text-rose-400" />
-          <span className="text-xs font-semibold text-rose-900 dark:text-rose-200 uppercase tracking-wide">
+          <Clock className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+          <span className="text-xs font-semibold text-blue-900 dark:text-blue-200 uppercase tracking-wide">
             Last 24h
           </span>
         </div>
@@ -127,17 +127,17 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
+    <div className="bg-blue-50/60 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-900 rounded-lg mb-6">
       <div className="flex items-center gap-1.5 px-4 pt-2 pb-1">
-        <Clock className="h-3.5 w-3.5 text-rose-600 dark:text-rose-400" />
-        <span className="text-xs font-semibold text-rose-900 dark:text-rose-200 uppercase tracking-wide">
+        <Clock className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+        <span className="text-xs font-semibold text-blue-900 dark:text-blue-200 uppercase tracking-wide">
           Last 24h
         </span>
       </div>
 
       <div className="grid grid-cols-3 gap-3 px-4 pb-2">
         <div className="col-span-2 flex items-start gap-2">
-          <Milk className="h-3 w-3 text-rose-600 dark:text-rose-400 flex-shrink-0 mt-0.5" />
+          <Milk className="h-3 w-3 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
           <div className="min-w-0 flex-1">
             <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
             <div className="text-xs text-muted-foreground">
@@ -184,11 +184,11 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
       </div>
 
       {recommendations.length > 0 && (
-        <div className="border-t border-rose-200 dark:border-rose-900">
+        <div className="border-t border-blue-200 dark:border-blue-900">
           <button
             type="button"
             onClick={() => setIsExpanded((v) => !v)}
-            className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-rose-900 dark:text-rose-200 hover:bg-rose-100/60 dark:hover:bg-rose-950/40 transition-colors"
+            className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-blue-900 dark:text-blue-200 hover:bg-blue-100/60 dark:hover:bg-blue-950/40 transition-colors"
             aria-expanded={isExpanded}
             aria-controls="last24h-recommendations-list"
           >

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { Milk, Baby, Clock, Pill, ArrowRight } from 'lucide-react';
+import { useState } from 'react';
+import { Milk, Baby, Clock, Pill, ArrowRight, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { timeAgoFromMs } from '@/lib/activity-form-utils';
@@ -34,6 +35,63 @@ interface Last24hSummaryCardProps {
   vitaminDTipEnabled?: boolean;
 }
 
+type Recommendation = {
+  key: string;
+  title: string;
+  body: string;
+  ctaLabel: string;
+  ctaRoute: string;
+};
+
+function getRecommendations(
+  summary: Last24hSummary,
+  vitaminDTipEnabled: boolean | undefined,
+): Recommendation[] {
+  const recs: Recommendation[] = [];
+  const { allFeedsAreBreastMilk, hasVitaminDInLast24h } = summary;
+  if (allFeedsAreBreastMilk && !hasVitaminDInLast24h && vitaminDTipEnabled !== false) {
+    recs.push({
+      key: 'vitamin-d',
+      title: 'Consider a Vitamin D supplement',
+      body: "Exclusively breastfed babies don't get enough Vitamin D from milk alone. Health authorities recommend 400 IU/day from birth. We noticed all feeds in the last 24h were breast milk and no Vitamin D was logged.",
+      ctaLabel: 'Log Vitamin D now',
+      ctaRoute: '/app/medical/create?tab=vitamin',
+    });
+  }
+  return recs;
+}
+
+function RecommendationCard({
+  rec,
+  onCtaClick,
+}: {
+  rec: Recommendation;
+  onCtaClick: () => void;
+}) {
+  return (
+    <div className="p-3 flex flex-col gap-2.5 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
+      <div className="flex items-center gap-2">
+        <Pill className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
+        <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+          {rec.title}
+        </h3>
+      </div>
+      <p className="text-xs leading-relaxed text-amber-900/85 dark:text-amber-200/85">
+        {rec.body}
+      </p>
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full h-8 text-xs border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-950/50 gap-1.5"
+        onClick={onCtaClick}
+      >
+        <span>{rec.ctaLabel}</span>
+        <ArrowRight className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}
+
 export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last24hSummaryCardProps) {
   const router = useRouter();
 
@@ -64,8 +122,9 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
     );
   }
 
-  const { feed, diapers, allFeedsAreBreastMilk, hasVitaminDInLast24h } = summary;
-  const showVitaminDTip = allFeedsAreBreastMilk && !hasVitaminDInLast24h && vitaminDTipEnabled !== false;
+  const { feed, diapers } = summary;
+  const recommendations = getRecommendations(summary, vitaminDTipEnabled);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   return (
     <div className="bg-rose-50/60 dark:bg-rose-950/20 border border-rose-200 dark:border-rose-900 rounded-lg mb-6">
@@ -124,26 +183,39 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
         </div>
       </div>
 
-      {showVitaminDTip && (
-        <div className="mx-4 mb-3 p-3 flex flex-col gap-2.5 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
-          <div className="flex items-center gap-2">
-            <Pill className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
-            <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-100">
-              Consider a Vitamin D supplement
-            </h3>
-          </div>
-          <p className="text-xs leading-relaxed text-amber-900/85 dark:text-amber-200/85">
-            Exclusively breastfed babies don&apos;t get enough Vitamin D from milk alone. Health authorities recommend 400 IU/day from birth. We noticed all feeds in the last 24h were breast milk and no Vitamin D was logged.
-          </p>
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full h-8 text-xs border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-950/50 gap-1.5"
-            onClick={() => router.push('/app/medical/create?tab=vitamin')}
+      {recommendations.length > 0 && (
+        <div className="border-t border-rose-200 dark:border-rose-900">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((v) => !v)}
+            className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-rose-900 dark:text-rose-200 hover:bg-rose-100/60 dark:hover:bg-rose-950/40 transition-colors"
+            aria-expanded={isExpanded}
+            aria-controls="last24h-recommendations-list"
           >
-            <span>Log Vitamin D now</span>
-            <ArrowRight className="h-3 w-3" />
-          </Button>
+            <span>
+              {recommendations.length}{' '}
+              {recommendations.length === 1 ? 'recommendation' : 'recommendations'}{' '}
+              available
+            </span>
+            <ChevronDown
+              className={`h-4 w-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            />
+          </button>
+
+          {isExpanded && (
+            <div
+              id="last24h-recommendations-list"
+              className="px-4 pb-3 pt-1 flex flex-col gap-2"
+            >
+              {recommendations.map((rec) => (
+                <RecommendationCard
+                  key={rec.key}
+                  rec={rec}
+                  onCtaClick={() => router.push(rec.ctaRoute)}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -125,20 +125,23 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
       </div>
 
       {showVitaminDTip && (
-        <div className="mx-4 mb-2 p-3 flex items-center justify-between bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
-          <div className="flex items-center gap-1.5">
-            <Pill className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
-            <span className="text-xs font-medium text-amber-900 dark:text-amber-200">
-              Breast milk lacks Vitamin D — consider supplements
-            </span>
+        <div className="mx-4 mb-3 p-3 flex flex-col gap-2.5 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
+          <div className="flex items-center gap-2">
+            <Pill className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
+            <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+              Consider a Vitamin D supplement
+            </h3>
           </div>
+          <p className="text-xs leading-relaxed text-amber-900/85 dark:text-amber-200/85">
+            Exclusively breastfed babies don&apos;t get enough Vitamin D from milk alone. Health authorities recommend 400 IU/day from birth. We noticed all feeds in the last 24h were breast milk and no Vitamin D was logged.
+          </p>
           <Button
             variant="outline"
             size="sm"
-            className="h-7 text-xs border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-950/50 shrink-0 gap-1"
+            className="w-full h-8 text-xs border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-950/50 gap-1.5"
             onClick={() => router.push('/app/medical/create?tab=vitamin')}
           >
-            <span>Log Vitamin D</span>
+            <span>Log Vitamin D now</span>
             <ArrowRight className="h-3 w-3" />
           </Button>
         </div>

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -127,56 +127,58 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
-    <div className="bg-blue-50/60 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-900 rounded-lg mb-6">
-      <div className="flex items-center gap-1.5 px-4 pt-2 pb-1">
-        <Clock className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
-        <span className="text-xs font-semibold text-blue-900 dark:text-blue-200 uppercase tracking-wide">
-          Last 24h
-        </span>
-      </div>
+    <>
+      <div className={`bg-blue-50/60 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-900 rounded-lg ${recommendations.length > 0 ? 'mb-3' : 'mb-6'}`}>
+        <div className="flex items-center gap-1.5 px-4 pt-2 pb-1">
+          <Clock className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+          <span className="text-xs font-semibold text-blue-900 dark:text-blue-200 uppercase tracking-wide">
+            Last 24h
+          </span>
+        </div>
 
-      <div className="grid grid-cols-3 gap-3 px-4 pb-2">
-        <div className="col-span-2 flex items-start gap-2">
-          <Milk className="h-3 w-3 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
-          <div className="min-w-0 flex-1">
-            <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
-            <div className="text-xs text-muted-foreground">
-              <div className="grid grid-cols-[auto_auto_1fr] gap-x-2 gap-y-0.5">
-                <span>Last:</span>
-                <span className="col-span-2 text-foreground">
-                  {feed.lastFeedAtMs !== null ? timeAgoFromMs(nowMs - feed.lastFeedAtMs) : DASH}
-                </span>
-                <span>3h:</span>
-                <span className="font-medium text-foreground">
-                  {formatMl(feed.last3hMl, feed.last3hMl > 0)}
-                </span>
-                <span className="font-medium text-foreground">
-                  {`· ${formatLatch(feed.last3hLatchSeconds, feed.last3hLatchSeconds > 0)}`}
-                </span>
-                <span>24h:</span>
-                <span className="font-medium text-foreground">
-                  {formatMl(feed.total24hMl, feed.bottleCount >= 1)}
-                </span>
-                <span className="font-medium text-foreground">
-                  {`· ${formatLatch(feed.total24hLatchSeconds, feed.latchCount >= 1)}`}
-                </span>
+        <div className="grid grid-cols-3 gap-3 px-4 pb-2">
+          <div className="col-span-2 flex items-start gap-2">
+            <Milk className="h-3 w-3 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-semibold text-foreground mb-0.5">Feed</p>
+              <div className="text-xs text-muted-foreground">
+                <div className="grid grid-cols-[auto_auto_1fr] gap-x-2 gap-y-0.5">
+                  <span>Last:</span>
+                  <span className="col-span-2 text-foreground">
+                    {feed.lastFeedAtMs !== null ? timeAgoFromMs(nowMs - feed.lastFeedAtMs) : DASH}
+                  </span>
+                  <span>3h:</span>
+                  <span className="font-medium text-foreground">
+                    {formatMl(feed.last3hMl, feed.last3hMl > 0)}
+                  </span>
+                  <span className="font-medium text-foreground">
+                    {`· ${formatLatch(feed.last3hLatchSeconds, feed.last3hLatchSeconds > 0)}`}
+                  </span>
+                  <span>24h:</span>
+                  <span className="font-medium text-foreground">
+                    {formatMl(feed.total24hMl, feed.bottleCount >= 1)}
+                  </span>
+                  <span className="font-medium text-foreground">
+                    {`· ${formatLatch(feed.total24hLatchSeconds, feed.latchCount >= 1)}`}
+                  </span>
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div className="flex items-start gap-2">
-          <Baby className="h-3 w-3 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
-          <div className="min-w-0 flex-1">
-            <p className="text-xs font-semibold text-foreground mb-0.5">Diapers</p>
-            <div className="text-xs text-muted-foreground">
-              <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
-                <span>Wet:</span>
-                <span className="font-medium text-foreground">{diapers.wet > 0 ? diapers.wet : DASH}</span>
-                <span>Mixed:</span>
-                <span className="font-medium text-foreground">{diapers.mixed > 0 ? diapers.mixed : DASH}</span>
-                <span>Dirty:</span>
-                <span className="font-medium text-foreground">{diapers.dirty > 0 ? diapers.dirty : DASH}</span>
+          <div className="flex items-start gap-2">
+            <Baby className="h-3 w-3 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-semibold text-foreground mb-0.5">Diapers</p>
+              <div className="text-xs text-muted-foreground">
+                <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+                  <span>Wet:</span>
+                  <span className="font-medium text-foreground">{diapers.wet > 0 ? diapers.wet : DASH}</span>
+                  <span>Mixed:</span>
+                  <span className="font-medium text-foreground">{diapers.mixed > 0 ? diapers.mixed : DASH}</span>
+                  <span>Dirty:</span>
+                  <span className="font-medium text-foreground">{diapers.dirty > 0 ? diapers.dirty : DASH}</span>
+                </div>
               </div>
             </div>
           </div>
@@ -184,11 +186,11 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
       </div>
 
       {recommendations.length > 0 && (
-        <div className="border-t border-red-200 dark:border-red-900">
+        <div className="bg-red-50/60 dark:bg-red-950/20 border border-red-200 dark:border-red-900 rounded-lg mb-6 overflow-hidden">
           <button
             type="button"
             onClick={() => setIsExpanded((v) => !v)}
-            className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+            className="w-full flex items-center justify-between px-4 py-2 text-xs font-medium text-red-700 dark:text-red-300 hover:bg-red-100/60 dark:hover:bg-red-950/40 transition-colors"
             aria-expanded={isExpanded}
             aria-controls="last24h-recommendations-list"
           >
@@ -218,6 +220,6 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
           )}
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -69,20 +69,20 @@ function RecommendationCard({
   onCtaClick: () => void;
 }) {
   return (
-    <div className="p-3 flex flex-col gap-2.5 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-md">
+    <div className="p-3 flex flex-col gap-2.5 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-md">
       <div className="flex items-center gap-2">
-        <Pill className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
-        <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+        <Pill className="h-4 w-4 text-red-600 dark:text-red-400 shrink-0" />
+        <h3 className="text-sm font-semibold text-red-900 dark:text-red-100">
           {rec.title}
         </h3>
       </div>
-      <p className="text-xs leading-relaxed text-amber-900/85 dark:text-amber-200/85">
+      <p className="text-xs leading-relaxed text-red-900/85 dark:text-red-200/85">
         {rec.body}
       </p>
       <Button
         variant="outline"
         size="sm"
-        className="w-full h-8 text-xs border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-950/50 gap-1.5"
+        className="w-full h-8 text-xs border-red-300 dark:border-red-700 text-red-800 dark:text-red-200 hover:bg-red-100 dark:hover:bg-red-950/50 gap-1.5"
         onClick={onCtaClick}
       >
         <span>{rec.ctaLabel}</span>


### PR DESCRIPTION
## Before

The Vitamin D tip was a single-line toast: a pill icon, "Breast milk lacks Vitamin D — consider supplements", and a compact "Log Vitamin D" button crammed into a horizontal flex row. On mobile the button competed with the text for space.

## After

A proper 3-region vertical notice with clear hierarchy:

1. **Header**: Pill icon + "Consider a Vitamin D supplement" (semibold title)
2. **Body**: Rationale paragraph — "Exclusively breastfed babies don't get enough Vitamin D from milk alone. Health authorities recommend 400 IU/day from birth. We noticed all feeds in the last 24h were breast milk and no Vitamin D was logged."
3. **CTA**: Full-width "Log Vitamin D now" button (was "Log Vitamin D")

Dark-mode safe amber palette preserved. Gating logic, prop signature, and route unchanged.

## Changes
- `Last24hSummaryCard.tsx`: Restructured tip block with `flex-col gap-2.5`, `mb-3`, updated icon size and full-width CTA
- `Last24hSummaryCard.spec.tsx`: Updated regex matches for new copy, added rationale paragraph test

Originated from user feedback on the home page tip layout.