### PR TITLE
feat(webapp): show recommendation preview labels on Last24h expander

### DIFF
--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.spec.tsx
@@ -293,7 +293,7 @@ describe('Last24hSummaryCard', () => {
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
 
-      const expander = screen.getByRole('button', { name: '1 recommendation available' });
+      const expander = screen.getByRole('button', { name: '1 recommendation available - Vit D supplement' });
       expect(expander).toBeInTheDocument();
       expect(expander).toHaveAttribute('aria-expanded', 'false');
       expect(screen.queryByText(/Consider a Vitamin D supplement/)).not.toBeInTheDocument();
@@ -348,7 +348,7 @@ describe('Last24hSummaryCard', () => {
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} vitaminDTipEnabled={true} />);
 
-      const expander = screen.getByRole('button', { name: '1 recommendation available' });
+      const expander = screen.getByRole('button', { name: '1 recommendation available - Vit D supplement' });
       expect(expander).toBeInTheDocument();
 
       fireEvent.click(expander);
@@ -364,7 +364,7 @@ describe('Last24hSummaryCard', () => {
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
 
-      const expander = screen.getByRole('button', { name: '1 recommendation available' });
+      const expander = screen.getByRole('button', { name: '1 recommendation available - Vit D supplement' });
 
       fireEvent.click(expander);
       expect(screen.getByText(/Consider a Vitamin D supplement/)).toBeInTheDocument();
@@ -381,7 +381,7 @@ describe('Last24hSummaryCard', () => {
         hasVitaminDInLast24h: false,
       };
       render(<Last24hSummaryCard summary={summary} nowMs={Date.now()} />);
-      expect(screen.getByRole('button', { name: '1 recommendation available' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '1 recommendation available - Vit D supplement' })).toBeInTheDocument();
     });
   });
 });

--- a/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
+++ b/apps/webapp/src/modules/baby-tracker/Last24hSummaryCard.tsx
@@ -38,10 +38,19 @@ interface Last24hSummaryCardProps {
 type Recommendation = {
   key: string;
   title: string;
+  shortLabel: string;
   body: string;
   ctaLabel: string;
   ctaRoute: string;
 };
+
+function formatRecommendationsExpanderLabel(recommendations: Recommendation[]): string {
+  const previews = recommendations.map((r) => r.shortLabel).join(', ');
+  if (recommendations.length === 1) {
+    return `1 recommendation available - ${previews}`;
+  }
+  return `${recommendations.length} recommendations available - ${previews}`;
+}
 
 function getRecommendations(
   summary: Last24hSummary,
@@ -53,6 +62,7 @@ function getRecommendations(
     recs.push({
       key: 'vitamin-d',
       title: 'Consider a Vitamin D supplement',
+      shortLabel: 'Vit D supplement',
       body: "Exclusively breastfed babies don't get enough Vitamin D from milk alone. Health authorities recommend 400 IU/day from birth. We noticed all feeds in the last 24h were breast milk and no Vitamin D was logged.",
       ctaLabel: 'Log Vitamin D now',
       ctaRoute: '/app/medical/create?tab=vitamin',
@@ -194,11 +204,7 @@ export function Last24hSummaryCard({ summary, nowMs, vitaminDTipEnabled }: Last2
             aria-expanded={isExpanded}
             aria-controls="last24h-recommendations-list"
           >
-            <span>
-              {recommendations.length}{' '}
-              {recommendations.length === 1 ? 'recommendation' : 'recommendations'}{' '}
-              available
-            </span>
+            <span>{formatRecommendationsExpanderLabel(recommendations)}</span>
             <ChevronDown
               className={`h-4 w-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
             />


### PR DESCRIPTION
## Summary
- Add `shortLabel` to recommendation items (Vitamin D: "Vit D supplement")
- Format collapsed expander button text with preview labels, e.g. `1 recommendation available - Vit D supplement`
- Update Last24hSummaryCard specs for new accessible button names

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] Verify expander shows preview text when Vitamin D tip conditions are met
- [ ] Expand/collapse still works and full recommendation cards render when expanded

Made with [Cursor](https://cursor.com)